### PR TITLE
Treat highlights as text boxes

### DIFF
--- a/lib/article_json/import/google_doc/html/node_analyzer.rb
+++ b/lib/article_json/import/google_doc/html/node_analyzer.rb
@@ -48,7 +48,6 @@ module ArticleJSON
                 !empty? &&
                 !image? &&
                 !text_box? &&
-                !highlight? &&
                 !quote?
           end
 
@@ -60,19 +59,11 @@ module ArticleJSON
           end
 
           # Check if the node starts a text box
-          # Text boxes start with a single line saying "Textbox:".
+          # Text boxes start with a single line saying "Textbox:" or "Highlight:".
           # @return [Boolean]
           def text_box?
             return @is_text_box if defined? @is_text_box
-            @is_text_box = has_text?('textbox:')
-          end
-
-          # Check if the node starts a highlight box
-          # Story highlights start with a single line saying "Highlight:".
-          # @return [Boolean]
-          def highlight?
-            return @is_highlight if defined? @is_highlight
-            @is_highlight = has_text?('highlight:')
+            @is_text_box = has_text?('textbox:') || has_text?('highlight:')
           end
 
           # Check if the node starts a quote
@@ -100,7 +91,6 @@ module ArticleJSON
             return :paragraph if paragraph?
             return :list if list?
             return :text_box if text_box?
-            return :highlight if highlight?
             return :quote if quote?
             return :image if image?
             :unknown

--- a/spec/article_json/import/google_doc/node_analyzer_spec.rb
+++ b/spec/article_json/import/google_doc/node_analyzer_spec.rb
@@ -120,7 +120,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
       it { should be false }
     end
 
-    context 'when the node contains the text to start a highlight' do
+    context 'when the node contains the text to start a highlight text box' do
       let(:xml_fragment) { '<p><span>Highlight:</span></p>' }
       it { should be false }
     end
@@ -208,21 +208,12 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
       it { should be true }
     end
 
-    context 'when the node does not contain the text to start a text box' do
-      let(:xml_fragment) { '<p><span>Foo Bar:</span></p>' }
-      it { should be false }
-    end
-  end
-
-  describe '#highlight?' do
-    subject { node.highlight? }
-
     context 'when the node contains the text to start a highlight' do
       let(:xml_fragment) { '<p><span>Highlight:</span></p>' }
       it { should be true }
     end
 
-    context 'when the node does not contain the text to start a highlight' do
+    context 'when the node does not contain the text to start a text box' do
       let(:xml_fragment) { '<p><span>Foo Bar:</span></p>' }
       it { should be false }
     end
@@ -267,7 +258,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
 
     context 'when the node contains the text to start a highlight' do
       let(:xml_fragment) { '<p><span>Highlight:</span></p>' }
-      it { should eq :highlight }
+      it { should eq :text_box }
     end
 
     context 'when the node contains the text to start a quote' do


### PR DESCRIPTION
They are basically the same, so now both `Highlight:` and `Textbox:` will start a text box.