### PR TITLE
Add scripts to load and parse google docs

### DIFF
--- a/bin/article_json_export_google_doc.rb
+++ b/bin/article_json_export_google_doc.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Simple script to load an HTML export for a Google document by ID.
+#
+# Usage:
+#
+#   ./bin/article_json_export_google_doc.rb $GOOGLE_DOC_ID
+#
+# Note: The document has to be publicly accessible via link. If the docuement is
+#       private, you can use the URL schema below and open it in a browser while
+#       being signed in to Google Drive.
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+require 'net/http'
+require 'uri'
+
+doc_id = ARGV.first
+url = "https://docs.google.com/feeds/download/documents/export/Export?id=#{doc_id}&exportFormat=html"
+puts Net::HTTP.get(URI.parse(url))

--- a/bin/article_json_parse_google_doc.rb
+++ b/bin/article_json_parse_google_doc.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+#
+# Simple script to read a Google Doc HTML export from STDIN and parse it.
+#
+# Usage:
+#
+#   ./bin/article_json_parse_google_doc.rb < my_document.html
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+require_relative '../lib/article_json'
+
+parser = ArticleJSON::Import::GoogleDoc::HTML::Parser.new(ARGF.read)
+puts parser.parsed_content.map(&:to_h).to_json


### PR DESCRIPTION
These little scripts make exporting and parsing google docs easy. For example, to load, parse, and pretty print the latest version of the reference document do:

```
$ export DOC_ID=1E4lncZE2jDkbE34eDyYQmXKA9O26BHUiwguz4S9qyE8
$ ./bin/article_json_export_google_doc.rb $DOC_ID \
    | ./bin/article_json_parse_google_doc.rb \
    | jq .
```