### PR TITLE
Add embedded element: Vimeo Video

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -17,4 +17,7 @@ require_relative 'article_json/import/google_doc/html/image_element'
 require_relative 'article_json/import/google_doc/html/text_box_element'
 require_relative 'article_json/import/google_doc/html/quote_element'
 
+require_relative 'article_json/import/google_doc/html/embedded_element'
+require_relative 'article_json/import/google_doc/html/embedded_vimeo_video_element'
+
 require_relative 'article_json/import/google_doc/html/parser'

--- a/lib/article_json/import/google_doc/html/embedded_element.rb
+++ b/lib/article_json/import/google_doc/html/embedded_element.rb
@@ -1,0 +1,88 @@
+module ArticleJSON
+  module Import
+    module GoogleDoc
+      module HTML
+        class EmbeddedElement
+          # @param [Nokogiri::XML::Node] node
+          # @param [Nokogiri::XML::Node] caption_node
+          # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
+          def initialize(node:, caption_node:, css_analyzer:)
+            @node = node
+            @caption_node = caption_node
+            @css_analyzer = css_analyzer
+          end
+
+          # Extract any potential tags, specified in brackets after the URL
+          # @return [Array[Symbol]]
+          def tags
+            match = /(.*?)[\s\u00A0]+\[(.*)\]/.match(@node.inner_text)
+            (match ? match[2] : '').split(' ')
+          end
+
+          # Parse the embed's caption node
+          # @return [Array[ArticleJSON::Import::GoogleDoc::HTML::TextElement]]
+          def caption
+            TextElement.extract(
+              node: @caption_node,
+              css_analyzer: @css_analyzer
+            )
+          end
+
+          # Hash representation of the embedded element
+          # @return [Hash]
+          def to_h
+            {
+              type: :embed,
+              embed_type: embed_type,
+              embed_id: embed_id,
+              tags: tags,
+              caption: caption.map(&:to_h),
+            }
+          end
+
+          class << self
+            # Build a embedded element based on the node's content
+            # @param [Nokogiri::XML::Node] node
+            # @param [Nokogiri::XML::Node] caption_node
+            # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
+            # @return [ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement]
+            def build(node:, caption_node:, css_analyzer:)
+              find_class(node.inner_text)
+                &.new(
+                  node: node,
+                  caption_node: caption_node,
+                  css_analyzer: css_analyzer
+                )
+            end
+
+            # Check if a node contains a supported embedded element
+            # @param [Nokogiri::XML::Node] node
+            # @return [Boolean]
+            def matches?(node)
+              !find_class(node.inner_text).nil?
+            end
+
+            private
+
+            # List of embedded element classes
+            # @return [ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement]
+            def element_classes
+              [
+                EmbeddedVimeoVideoElement,
+              ]
+            end
+
+            # Find the first matching class for a given (URL) string
+            # @param [String] text
+            # @return [Class]
+            def find_class(text)
+              text = text.strip.downcase
+              return nil if text.empty?
+              element_classes.find { |klass| klass.matches?(text) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/import/google_doc/html/embedded_vimeo_video_element.rb
+++ b/lib/article_json/import/google_doc/html/embedded_vimeo_video_element.rb
@@ -1,0 +1,38 @@
+module ArticleJSON
+  module Import
+    module GoogleDoc
+      module HTML
+        class EmbeddedVimeoVideoElement < EmbeddedElement
+          # The type of this embedded element
+          # @return [Symbol]
+          def embed_type
+            :vimeo_video
+          end
+
+          # Extract the video ID from an URL
+          # @return [String]
+          def embed_id
+            match = @node.inner_text.strip.match(self.class.url_regexp)
+            match[1] if match
+          end
+
+          class << self
+            # Check if a given string is a Vimeo embedding
+            # @param [String] text
+            # @return [Boolean]
+            def matches?(text)
+              !!(url_regexp =~ text)
+            end
+
+            # Regular expression to check if a given string is a Vimeo URL
+            # Can also be used to extract the ID from the URL
+            # @return [Regexp]
+            def url_regexp
+              %r(^\S*vimeo.com/(?:.*#|.*/)?([0-9]+))i
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/import/google_doc/embedded_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_element_spec.rb
@@ -1,0 +1,97 @@
+describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement do
+  subject(:element) do
+    described_class.new(
+      node: node,
+      caption_node: caption_node,
+      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
+    )
+  end
+
+  let(:node) { Nokogiri::XML.fragment(html.strip) }
+  let(:html) { '' }
+  let(:vimeo_video_html) do
+    <<-html
+      <p>
+        <span>
+          <a href="https://vimeo.com/123">https://vimeo.com/123</a>
+          <span>&nbsp;[vimeo test]</span>
+        </span>
+      </p>
+    html
+  end
+
+  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
+  let(:caption_html) { '<p><span>Caption</span></p>' }
+
+  describe '#.tags' do
+    subject { element.tags }
+
+    context 'when there are tags' do
+      let(:html) { vimeo_video_html }
+      it { should match_array %w(vimeo test) }
+    end
+
+    context 'when there are no tags' do
+      it { should match_array [] }
+    end
+  end
+
+  describe '#caption' do
+    subject { element.caption }
+
+    it 'returns a list of text elements' do
+      expect(subject).to be_an Array
+      expect(subject.size).to eq 1
+
+      expect(subject)
+        .to all be_a ArticleJSON::Import::GoogleDoc::HTML::TextElement
+
+      expect(subject.first.content).to eq 'Caption'
+    end
+  end
+
+  describe '.build' do
+    subject do
+      described_class.build(
+        node: node,
+        caption_node: caption_node,
+        css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
+      )
+    end
+
+    context 'when the node is not an embedded element' do
+      it { should be nil }
+    end
+
+    context 'when the node is an embedded vimeo video' do
+      let(:html) { vimeo_video_html }
+      let(:expected_class) do
+        ArticleJSON::Import::GoogleDoc::HTML::EmbeddedVimeoVideoElement
+      end
+      it { should be_a expected_class }
+    end
+  end
+
+  describe '.matches?' do
+    subject { described_class.matches?(node) }
+
+    context 'when the node is an embedded vimeo video' do
+      let(:html) { vimeo_video_html }
+      it { should be true }
+    end
+
+    context 'when the node is not an embedded element' do
+      let(:html) do
+        <<-html
+          <p>
+            <span>
+              <a href="https://www.devex.com">https://www.devex.com</a>
+              <span>&nbsp;[devex]</span>
+            </span>
+          </p>
+        html
+      end
+      it { should be false }
+    end
+  end
+end

--- a/spec/article_json/import/google_doc/embedded_vimeo_video_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_vimeo_video_element_spec.rb
@@ -1,0 +1,67 @@
+describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedVimeoVideoElement do
+  subject(:element) do
+    described_class.new(
+      node: node,
+      caption_node: caption_node,
+      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
+    )
+  end
+
+  let(:node) { Nokogiri::XML.fragment(html.strip) }
+  let(:html) do
+    <<-html
+      <p>
+        <span>
+          <a href="https://vimeo.com/123">https://vimeo.com/123</a>
+          <span>&nbsp;[vimeo test]</span>
+        </span>
+      </p>
+    html
+  end
+
+  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
+  let(:caption_html) { '<p><span>Caption</span></p>' }
+
+  describe '#embed_type' do
+    subject { element.embed_type }
+    it { should eq :vimeo_video }
+  end
+
+  describe '#embed_id' do
+    subject { element.embed_id }
+    it { should eq '123' }
+  end
+
+  describe 'to_h' do
+    subject { element.to_h }
+
+    it 'returns a proper Hash' do
+      expect(subject).to be_a Hash
+      expect(subject[:type]).to eq :embed
+      expect(subject[:embed_type]).to eq :vimeo_video
+      expect(subject[:embed_id]).to eq '123'
+      expect(subject[:tags]).to match_array %w(vimeo test)
+      expect(subject[:caption].first[:content]).to eq 'Caption'
+    end
+  end
+
+  describe '.matches?' do
+    subject { described_class.matches?(url) }
+
+    context 'when passed a text containing a vimeo URL' do
+      let(:url) { 'https://vimeo.com/123' }
+      it { should be true }
+    end
+
+    context 'when passed a text containing another URL' do
+      let(:url) { 'https://www.devex.com/news/vimeo-videos-rock-123' }
+      it { should be false }
+    end
+  end
+
+  describe '.url_regexp' do
+    subject { described_class.url_regexp }
+    it { should be_a Regexp }
+    it { should match 'https://vimeo.com/123' }
+  end
+end


### PR DESCRIPTION
Embedded elements are specified by URL and can have optional tags following in brackets. The paragraph holds the caption.

Sorry for the big PR, but it's hard to split this up any further...