### PR TITLE
Add embedded elements to parser

### DIFF
--- a/lib/article_json/import/google_doc/html/embedded_element.rb
+++ b/lib/article_json/import/google_doc/html/embedded_element.rb
@@ -12,6 +12,20 @@ module ArticleJSON
             @css_analyzer = css_analyzer
           end
 
+          # Extract the video ID from an URL
+          # @return [String]
+          def embed_id
+            match = @node.inner_text.strip.match(self.class.url_regexp)
+            match[1] if match
+          end
+
+          # The type of this embedded element
+          # To be implemented by sub classes!
+          # @return [Symbol]
+          def embed_type
+            raise NotImplementedError
+          end
+
           # Extract any potential tags, specified in brackets after the URL
           # @return [Array[Symbol]]
           def tags
@@ -41,6 +55,20 @@ module ArticleJSON
           end
 
           class << self
+            # Check if a given string is a Youtube embedding
+            # @param [String] text
+            # @return [Boolean]
+            def matches?(text)
+              !!(url_regexp =~ text)
+            end
+
+            # Regular expression to check if node content is embeddable element
+            # Is also used to extract the ID from the URL.
+            # @return [Regexp]
+            def url_regexp
+              raise NotImplementedError
+            end
+
             # Build a embedded element based on the node's content
             # @param [Nokogiri::XML::Node] node
             # @param [Nokogiri::XML::Node] caption_node
@@ -58,7 +86,7 @@ module ArticleJSON
             # Check if a node contains a supported embedded element
             # @param [Nokogiri::XML::Node] node
             # @return [Boolean]
-            def matches?(node)
+            def supported?(node)
               !find_class(node.inner_text).nil?
             end
 

--- a/lib/article_json/import/google_doc/html/embedded_vimeo_video_element.rb
+++ b/lib/article_json/import/google_doc/html/embedded_vimeo_video_element.rb
@@ -9,21 +9,7 @@ module ArticleJSON
             :vimeo_video
           end
 
-          # Extract the video ID from an URL
-          # @return [String]
-          def embed_id
-            match = @node.inner_text.strip.match(self.class.url_regexp)
-            match[1] if match
-          end
-
           class << self
-            # Check if a given string is a Vimeo embedding
-            # @param [String] text
-            # @return [Boolean]
-            def matches?(text)
-              !!(url_regexp =~ text)
-            end
-
             # Regular expression to check if a given string is a Vimeo URL
             # Can also be used to extract the ID from the URL
             # @return [Regexp]

--- a/lib/article_json/import/google_doc/html/node_analyzer.rb
+++ b/lib/article_json/import/google_doc/html/node_analyzer.rb
@@ -48,7 +48,8 @@ module ArticleJSON
                 !empty? &&
                 !image? &&
                 !text_box? &&
-                !quote?
+                !quote? &&
+                !embed?
           end
 
           # Check if the node contains an ordered or unordered list
@@ -81,6 +82,13 @@ module ArticleJSON
             @is_image = node.xpath('.//img').length > 0
           end
 
+          # Check if the node contains an embedded element
+          # @return [Boolean]
+          def embed?
+            return @is_embed if defined? @is_embed
+            @is_embed = EmbeddedElement.matches?(node)
+          end
+
           # Determine the type of this node
           # The type is one of the elements supported by article_json.
           # @return [Symbol]
@@ -93,6 +101,7 @@ module ArticleJSON
             return :text_box if text_box?
             return :quote if quote?
             return :image if image?
+            return :embed if embed?
             :unknown
           end
         end

--- a/lib/article_json/import/google_doc/html/node_analyzer.rb
+++ b/lib/article_json/import/google_doc/html/node_analyzer.rb
@@ -86,7 +86,7 @@ module ArticleJSON
           # @return [Boolean]
           def embed?
             return @is_embed if defined? @is_embed
-            @is_embed = EmbeddedElement.matches?(node)
+            @is_embed = EmbeddedElement.supported?(node)
           end
 
           # Determine the type of this node

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -43,6 +43,7 @@ module ArticleJSON
             when :image then parse_image
             when :text_box then parse_text_box
             when :quote then parse_quote
+            when :embed then parse_embed
             when :hr, :empty, :unknown then nil
             end
           end
@@ -93,6 +94,15 @@ module ArticleJSON
               nodes << @body_enumerator.next
             end
             QuoteElement.new(nodes: nodes, css_analyzer: @css_analyzer)
+          end
+
+          # @return [ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement]
+          def parse_embed
+            EmbeddedElement.build(
+              node: @current_node.node,
+              caption_node: @body_enumerator.next,
+              css_analyzer: @css_analyzer
+            )
           end
 
           # @return [Boolean]

--- a/spec/article_json/import/google_doc/embedded_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_element_spec.rb
@@ -23,6 +23,12 @@ describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement do
   let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
   let(:caption_html) { '<p><span>Caption</span></p>' }
 
+  describe '#embed_type' do
+    it 'is not implemented' do
+      expect { element.embed_type }.to raise_error NotImplementedError
+    end
+  end
+
   describe '#.tags' do
     subject { element.tags }
 
@@ -50,6 +56,12 @@ describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement do
     end
   end
 
+  describe '.url_regexp' do
+    it 'is not implemented' do
+      expect { described_class.url_regexp }.to raise_error NotImplementedError
+    end
+  end
+
   describe '.build' do
     subject do
       described_class.build(
@@ -72,8 +84,8 @@ describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement do
     end
   end
 
-  describe '.matches?' do
-    subject { described_class.matches?(node) }
+  describe '.supported?' do
+    subject { described_class.supported?(node) }
 
     context 'when the node is an embedded vimeo video' do
       let(:html) { vimeo_video_html }

--- a/spec/article_json/import/google_doc/node_analyzer_spec.rb
+++ b/spec/article_json/import/google_doc/node_analyzer_spec.rb
@@ -165,6 +165,15 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
     end
   end
 
+  describe '#embed?' do
+    let(:xml_fragment) { '<p><span>some embedding</span></p>' }
+    it 'calls EmbeddedElement.matches?' do
+      expect(ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement)
+        .to receive(:matches?).with(nokogiri_node).and_return(true)
+      expect(node.embed?).to be true
+    end
+  end
+
   describe '#list?' do
     subject { node.list? }
 
@@ -284,6 +293,15 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
     context 'when the node is a just normal text' do
       let(:xml_fragment) { '<p><span>Foo</span><span>Bar</span></p>' }
       it { should eq :paragraph }
+    end
+
+    context 'when the node is a embedding' do
+      let(:xml_fragment) { '<p><span>some embedding</span></p>' }
+      it 'calls EmbeddedElement.matches?' do
+        expect(ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement)
+          .to receive(:matches?).with(nokogiri_node).and_return(true)
+        expect(subject).to eq :embed
+      end
     end
 
     context 'when the node is something else that we do not support' do

--- a/spec/article_json/import/google_doc/node_analyzer_spec.rb
+++ b/spec/article_json/import/google_doc/node_analyzer_spec.rb
@@ -167,9 +167,9 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
 
   describe '#embed?' do
     let(:xml_fragment) { '<p><span>some embedding</span></p>' }
-    it 'calls EmbeddedElement.matches?' do
+    it 'calls EmbeddedElement.supported?' do
       expect(ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement)
-        .to receive(:matches?).with(nokogiri_node).and_return(true)
+        .to receive(:supported?).with(nokogiri_node).and_return(true)
       expect(node.embed?).to be true
     end
   end
@@ -297,9 +297,9 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
 
     context 'when the node is a embedding' do
       let(:xml_fragment) { '<p><span>some embedding</span></p>' }
-      it 'calls EmbeddedElement.matches?' do
+      it 'calls EmbeddedElement.supported?' do
         expect(ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement)
-          .to receive(:matches?).with(nokogiri_node).and_return(true)
+          .to receive(:supported?).with(nokogiri_node).and_return(true)
         expect(subject).to eq :embed
       end
     end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -437,27 +437,13 @@
     ]
   },
   {
-    "type": "paragraph",
-    "content": [
-      {
-        "type": "text",
-        "content": "http://vimeo.com/42315417",
-        "bold": false,
-        "italic": false,
-        "href": "http://vimeo.com/42315417"
-      },
-      {
-        "type": "text",
-        "content": " [devex]",
-        "bold": false,
-        "italic": false,
-        "href": null
-      }
-    ]
-  },
-  {
-    "type": "paragraph",
-    "content": [
+    "type": "embed",
+    "embed_type": "vimeo_video",
+    "embed_id": "42315417",
+    "tags": [
+      "devex"
+    ],
+    "caption": [
       {
         "type": "text",
         "content": "The paragraph following the URL is the video’s caption.",


### PR DESCRIPTION
### Support embedded elements in parser
Because the parser now detects embedded vimeo videos, the expected results of parsing the reference document in the integration tests had to be updated...

### Refactor embedded element class
Moving the to methods `#embed_id` and `.matches?` up into the base class, as they can be shared among all sub classes. This requires a rename of `.matches?` to `supported?`, which is less confusing anyway.
