### PR TITLE
Refactor embeddable element specs

### DIFF
--- a/spec/article_json/import/google_doc/embedded_element_shared.rb
+++ b/spec/article_json/import/google_doc/embedded_element_shared.rb
@@ -1,0 +1,64 @@
+shared_context 'for an embeddable object' do
+  subject(:element) do
+    described_class.new(
+      node: Nokogiri::HTML.fragment(html.strip),
+      caption_node: Nokogiri::HTML.fragment('<p><span>Caption</span></p>'),
+      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
+    )
+  end
+
+  let(:url) { url_examples.sample }
+  let(:html) do
+    <<-html
+      <p>
+        <span>
+          <a href="#{url}">#{url}</a>
+          <span>&nbsp;[#{expected_tags.join(' ')}]</span>
+        </span>
+      </p>
+    html
+  end
+
+  describe '#embed_type' do
+    subject { element.embed_type }
+    it { should eq expected_embed_type }
+  end
+
+  describe '#embed_id' do
+    subject { element.embed_id }
+    it { should eq expected_embed_id }
+  end
+
+  describe 'to_h' do
+    subject { element.to_h }
+    it 'returns a proper Hash' do
+      expect(subject).to be_a Hash
+      expect(subject[:type]).to eq :embed
+      expect(subject[:embed_type]).to eq expected_embed_type
+      expect(subject[:embed_id]).to eq expected_embed_id
+      expect(subject[:tags]).to match_array expected_tags
+      expect(subject[:caption].first[:content]).to eq 'Caption'
+    end
+  end
+
+  describe '.matches?' do
+    context 'when passed a text containing a tweet URL' do
+      subject { described_class.matches?(url_examples.sample) }
+      it { should be true }
+    end
+
+    context 'when passed a text containing another URL' do
+      subject { described_class.matches?(invalid_url_example) }
+      it { should be false }
+    end
+  end
+
+  describe '.url_regexp' do
+    subject { described_class.url_regexp }
+    it { should be_a Regexp }
+    it 'matches a lot of different example URLs' do
+      url_examples.each { |url| expect(subject).to match url }
+    end
+    it { should_not match invalid_url_example }
+  end
+end

--- a/spec/article_json/import/google_doc/embedded_facebook_video_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_facebook_video_element_spec.rb
@@ -1,96 +1,32 @@
+require_relative 'embedded_element_shared'
+
 describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedFacebookVideoElement do
-  subject(:element) do
-    described_class.new(
-      node: node,
-      caption_node: caption_node,
-      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
-    )
-  end
-
-  let(:node) { Nokogiri::XML.fragment(html.strip) }
-  let(:html) do
-    <<-html
-      <p>
-        <span>
-          <a href="https://www.facebook.com/Devex/videos/#{video_id}">
-            https://www.facebook.com/Devex/videos/#{video_id}
-          </a>
-          <span>&nbsp;[facebook test]</span>
-        </span>
-      </p>
-    html
-  end
-
-  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
-  let(:caption_html) { '<p><span>Caption</span></p>' }
-
-  let(:video_id) { '1814600831891266' }
-  let(:url_examples) do
-    %W(
-      https://www.facebook.com/Devex/videos/#{video_id}/
-      https://www.facebook.com/video.php?id=#{video_id}
-      https://www.facebook.com/video.php?v=#{video_id}
-      https://facebook.com/Devex/videos/#{video_id}/
-      https://facebook.com/video.php?id=#{video_id}
-      https://facebook.com/video.php?v=#{video_id}
-      http://www.facebook.com/Devex/videos/#{video_id}/
-      http://www.facebook.com/video.php?id=#{video_id}
-      http://www.facebook.com/video.php?v=#{video_id}
-      http://facebook.com/Devex/videos/#{video_id}/
-      http://facebook.com/video.php?id=#{video_id}
-      http://facebook.com/video.php?v=#{video_id}
-      www.facebook.com/Devex/videos/#{video_id}/
-      www.facebook.com/video.php?id=#{video_id}
-      www.facebook.com/video.php?v=#{video_id}
-      facebook.com/Devex/videos/#{video_id}/
-      facebook.com/video.php?id=#{video_id}
-      facebook.com/video.php?v=#{video_id}
-    )
-  end
-
-  describe '#embed_type' do
-    subject { element.embed_type }
-    it { should eq :facebook_video }
-  end
-
-  describe '#embed_id' do
-    subject { element.embed_id }
-    it { should eq video_id }
-  end
-
-  describe 'to_h' do
-    subject { element.to_h }
-
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :embed
-      expect(subject[:embed_type]).to eq :facebook_video
-      expect(subject[:embed_id]).to eq video_id
-      expect(subject[:tags]).to match_array %w(facebook test)
-      expect(subject[:caption].first[:content]).to eq 'Caption'
-    end
-  end
-
-  describe '.matches?' do
-    subject { described_class.matches?(url) }
-
-    context 'when passed a text containing a Facebook video URL' do
-      let(:url) { url_examples.sample }
-      it { should be true }
-    end
-
-    context 'when passed a text containing another URL' do
-      let(:url) { 'https://www.devex.com/news/facebook-videos-hoho-123' }
-      it { should be false }
-    end
-  end
-
-  describe '.url_regexp' do
-    subject { described_class.url_regexp }
-
-    it { should be_a Regexp }
-    it 'matches a lot of different Facebook video URLs' do
-      url_examples.each { |url| expect(subject).to match url }
+  include_context 'for an embeddable object' do
+    let(:expected_embed_type) { :facebook_video }
+    let(:expected_embed_id) { '1814600831891266' }
+    let(:expected_tags) { %w(facebook test) }
+    let(:invalid_url_example) { 'https://www.devex.com/news/facebook-video-12' }
+    let(:url_examples) do
+      %W(
+        https://www.facebook.com/Devex/videos/#{expected_embed_id}/
+        https://www.facebook.com/video.php?id=#{expected_embed_id}
+        https://www.facebook.com/video.php?v=#{expected_embed_id}
+        https://facebook.com/Devex/videos/#{expected_embed_id}/
+        https://facebook.com/video.php?id=#{expected_embed_id}
+        https://facebook.com/video.php?v=#{expected_embed_id}
+        http://www.facebook.com/Devex/videos/#{expected_embed_id}/
+        http://www.facebook.com/video.php?id=#{expected_embed_id}
+        http://www.facebook.com/video.php?v=#{expected_embed_id}
+        http://facebook.com/Devex/videos/#{expected_embed_id}/
+        http://facebook.com/video.php?id=#{expected_embed_id}
+        http://facebook.com/video.php?v=#{expected_embed_id}
+        www.facebook.com/Devex/videos/#{expected_embed_id}/
+        www.facebook.com/video.php?id=#{expected_embed_id}
+        www.facebook.com/video.php?v=#{expected_embed_id}
+        facebook.com/Devex/videos/#{expected_embed_id}/
+        facebook.com/video.php?id=#{expected_embed_id}
+        facebook.com/video.php?v=#{expected_embed_id}
+      )
     end
   end
 end

--- a/spec/article_json/import/google_doc/embedded_slideshare_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_slideshare_element_spec.rb
@@ -1,83 +1,25 @@
+require_relative 'embedded_element_shared'
+
 describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedSlideshareElement do
-  subject(:element) do
-    described_class.new(
-      node: node,
-      caption_node: caption_node,
-      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
-    )
-  end
+  include_context 'for an embeddable object' do
+    let(:slideshare_handle) { 'Devex' }
+    let(:slide_id) { 'the-best-global-development-quotes-of-2012' }
 
-  let(:node) { Nokogiri::XML.fragment(html.strip) }
-  let(:html) do
-    <<-html
-      <p>
-        <span>
-          <a href="https://www.slideshare.net/Devex/#{slide_id}">
-            https://www.slideshare.net/Devex/#{slide_id}
-          </a>
-          <span>&nbsp;[slideshare test]</span>
-        </span>
-      </p>
-    html
-  end
-
-  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
-  let(:caption_html) { '<p><span>Caption</span></p>' }
-  let(:slide_id) { 'the-best-global-development-quotes-of-2012' }
-  let(:url_examples) do
-    %W(
-      slideshare.net/Devex/#{slide_id}
-      http://slideshare.net/Devex/#{slide_id}
-      https://slideshare.net/Devex/#{slide_id}
-      www.slideshare.net/Devex/#{slide_id}
-      http://www.slideshare.net/Devex/#{slide_id}
-      https://www.slideshare.net/Devex/#{slide_id}
-    )
-  end
-
-  describe '#embed_type' do
-    subject { element.embed_type }
-    it { should eq :slideshare }
-  end
-
-  describe '#embed_id' do
-    subject { element.embed_id }
-    it { should eq "Devex/#{slide_id}" }
-  end
-
-  describe 'to_h' do
-    subject { element.to_h }
-
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :embed
-      expect(subject[:embed_type]).to eq :slideshare
-      expect(subject[:embed_id]).to eq "Devex/#{slide_id}"
-      expect(subject[:tags]).to match_array %w(slideshare test)
-      expect(subject[:caption].first[:content]).to eq 'Caption'
-    end
-  end
-
-  describe '.matches?' do
-    subject { described_class.matches?(url) }
-
-    context 'when passed a text containing a Slideshare URL' do
-      let(:url) { url_examples.sample }
-      it { should be true }
-    end
-
-    context 'when passed a text containing another URL' do
-      let(:url) { 'https://www.devex.com/news/slideshare-deck-123' }
-      it { should be false }
-    end
-  end
-
-  describe '.url_regexp' do
-    subject { described_class.url_regexp }
-
-    it { should be_a Regexp }
-    it 'matches a lot of different slideshare URLs' do
-      url_examples.each { |url| expect(subject).to match url }
+    let(:expected_embed_type) { :slideshare }
+    let(:expected_embed_id) { "#{slideshare_handle}/#{slide_id}" }
+    let(:expected_tags) { %w(slideshare test) }
+    let(:invalid_url_example) { 'https://www.devex.com/news/slideshare-123' }
+    let(:invalid_url_example) { 'https://www.devex.com/news/slideshare-123' }
+    let(:invalid_url_example) { 'https://www.devex.com/news/slideshare-123' }
+    let(:url_examples) do
+      %W(
+        slideshare.net/#{slideshare_handle}/#{slide_id}
+        http://slideshare.net/#{slideshare_handle}/#{slide_id}
+        https://slideshare.net/#{slideshare_handle}/#{slide_id}
+        www.slideshare.net/#{slideshare_handle}/#{slide_id}
+        http://www.slideshare.net/#{slideshare_handle}/#{slide_id}
+        https://www.slideshare.net/#{slideshare_handle}/#{slide_id}
+      )
     end
   end
 end

--- a/spec/article_json/import/google_doc/embedded_tweet_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_tweet_element_spec.rb
@@ -1,97 +1,37 @@
+require_relative 'embedded_element_shared'
+
 describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedTweetElement do
-  subject(:element) do
-    described_class.new(
-      node: node,
-      caption_node: caption_node,
-      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
-    )
-  end
+  include_context 'for an embeddable object' do
+    let(:twitter_handle) { 'd3v3x' }
+    let(:tweet_id) { '55460863903059968' }
 
-  let(:node) { Nokogiri::XML.fragment(html.strip) }
-  let(:html) do
-    <<-html
-      <p>
-        <span>
-          <a href="https://twitter.com/d3v3x/status/#{tweet_id}">
-            https://twitter.com/d3v3x/status/#{tweet_id}
-          </a>
-          <span>&nbsp;[twitter test]</span>
-        </span>
-      </p>
-    html
-  end
+    let(:expected_embed_type) { :tweet }
+    let(:expected_embed_id) { "#{twitter_handle}/#{tweet_id}" }
+    let(:expected_tags) { %w(twitter test) }
+    let(:invalid_url_example) { 'https://www.devex.com/twitter-fun-123' }
+    let(:url_examples) do
+      %W(
+        twitter.com/#{twitter_handle}/status/#{tweet_id}
+        http://twitter.com/#{twitter_handle}/status/#{tweet_id}
+        https://twitter.com/#{twitter_handle}/status/#{tweet_id}
+        www.twitter.com/#{twitter_handle}/status/#{tweet_id}
+        http://www.twitter.com/#{twitter_handle}/status/#{tweet_id}
+        https://www.twitter.com/#{twitter_handle}/status/#{tweet_id}
 
-  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
-  let(:caption_html) { '<p><span>Caption</span></p>' }
-  let(:tweet_id) { '55460863903059968' }
-  let(:url_examples) do
-    %W(
-      twitter.com/d3v3x/status/#{tweet_id}
-      http://twitter.com/d3v3x/status/#{tweet_id}
-      https://twitter.com/d3v3x/status/#{tweet_id}
-      www.twitter.com/d3v3x/status/#{tweet_id}
-      http://www.twitter.com/d3v3x/status/#{tweet_id}
-      https://www.twitter.com/d3v3x/status/#{tweet_id}
+        twitter.com/#{twitter_handle}/statuses/#{tweet_id}
+        http://twitter.com/#{twitter_handle}/statuses/#{tweet_id}
+        https://twitter.com/#{twitter_handle}/statuses/#{tweet_id}
+        www.twitter.com/#{twitter_handle}/statuses/#{tweet_id}
+        http://www.twitter.com/#{twitter_handle}/statuses/#{tweet_id}
+        https://www.twitter.com/#{twitter_handle}/statuses/#{tweet_id}
 
-      twitter.com/d3v3x/statuses/#{tweet_id}
-      http://twitter.com/d3v3x/statuses/#{tweet_id}
-      https://twitter.com/d3v3x/statuses/#{tweet_id}
-      www.twitter.com/d3v3x/statuses/#{tweet_id}
-      http://www.twitter.com/d3v3x/statuses/#{tweet_id}
-      https://www.twitter.com/d3v3x/statuses/#{tweet_id}
-
-      twitter.com/d3v3x##{tweet_id}
-      http://twitter.com/d3v3x##{tweet_id}
-      https://twitter.com/d3v3x##{tweet_id}
-      www.twitter.com/d3v3x##{tweet_id}
-      http://www.twitter.com/d3v3x##{tweet_id}
-      https://www.twitter.com/d3v3x##{tweet_id}
-    )
-  end
-
-  describe '#embed_type' do
-    subject { element.embed_type }
-    it { should eq :tweet }
-  end
-
-  describe '#embed_id' do
-    subject { element.embed_id }
-    it { should eq "d3v3x/#{tweet_id}" }
-  end
-
-  describe 'to_h' do
-    subject { element.to_h }
-
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :embed
-      expect(subject[:embed_type]).to eq :tweet
-      expect(subject[:embed_id]).to eq "d3v3x/#{tweet_id}"
-      expect(subject[:tags]).to match_array %w(twitter test)
-      expect(subject[:caption].first[:content]).to eq 'Caption'
-    end
-  end
-
-  describe '.matches?' do
-    subject { described_class.matches?(url) }
-
-    context 'when passed a text containing a tweet URL' do
-      let(:url) { url_examples.sample }
-      it { should be true }
-    end
-
-    context 'when passed a text containing another URL' do
-      let(:url) { 'https://www.devex.com/news/twitter-tweets-r-fun-123' }
-      it { should be false }
-    end
-  end
-
-  describe '.url_regexp' do
-    subject { described_class.url_regexp }
-
-    it { should be_a Regexp }
-    it 'matches a lot of different Twitter URLs' do
-      url_examples.each { |url| expect(subject).to match url }
+        twitter.com/#{twitter_handle}##{tweet_id}
+        http://twitter.com/#{twitter_handle}##{tweet_id}
+        https://twitter.com/#{twitter_handle}##{tweet_id}
+        www.twitter.com/#{twitter_handle}##{tweet_id}
+        http://www.twitter.com/#{twitter_handle}##{tweet_id}
+        https://www.twitter.com/#{twitter_handle}##{tweet_id}
+      )
     end
   end
 end

--- a/spec/article_json/import/google_doc/embedded_vimeo_video_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_vimeo_video_element_spec.rb
@@ -1,67 +1,20 @@
+require_relative 'embedded_element_shared'
+
 describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedVimeoVideoElement do
-  subject(:element) do
-    described_class.new(
-      node: node,
-      caption_node: caption_node,
-      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
-    )
-  end
-
-  let(:node) { Nokogiri::XML.fragment(html.strip) }
-  let(:html) do
-    <<-html
-      <p>
-        <span>
-          <a href="https://vimeo.com/123">https://vimeo.com/123</a>
-          <span>&nbsp;[vimeo test]</span>
-        </span>
-      </p>
-    html
-  end
-
-  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
-  let(:caption_html) { '<p><span>Caption</span></p>' }
-
-  describe '#embed_type' do
-    subject { element.embed_type }
-    it { should eq :vimeo_video }
-  end
-
-  describe '#embed_id' do
-    subject { element.embed_id }
-    it { should eq '123' }
-  end
-
-  describe 'to_h' do
-    subject { element.to_h }
-
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :embed
-      expect(subject[:embed_type]).to eq :vimeo_video
-      expect(subject[:embed_id]).to eq '123'
-      expect(subject[:tags]).to match_array %w(vimeo test)
-      expect(subject[:caption].first[:content]).to eq 'Caption'
+  include_context 'for an embeddable object' do
+    let(:expected_embed_type) { :vimeo_video }
+    let(:expected_embed_id) { '123' }
+    let(:expected_tags) { %w(vimeo test) }
+    let(:invalid_url_example) { 'https://www.devex.com/news/facebook-video-12' }
+    let(:url_examples) do
+      %W(
+        https://www.vimeo.com/#{expected_embed_id}?foo=bar
+        http://www.vimeo.com/#{expected_embed_id}?foo=bar
+        www.vimeo.com/#{expected_embed_id}?foo=bar
+        https://vimeo.com/#{expected_embed_id}?foo=bar
+        http://vimeo.com/#{expected_embed_id}?foo=bar
+        vimeo.com/#{expected_embed_id}?foo=bar
+      )
     end
-  end
-
-  describe '.matches?' do
-    subject { described_class.matches?(url) }
-
-    context 'when passed a text containing a vimeo URL' do
-      let(:url) { 'https://vimeo.com/123' }
-      it { should be true }
-    end
-
-    context 'when passed a text containing another URL' do
-      let(:url) { 'https://www.devex.com/news/vimeo-videos-rock-123' }
-      it { should be false }
-    end
-  end
-
-  describe '.url_regexp' do
-    subject { described_class.url_regexp }
-    it { should be_a Regexp }
-    it { should match 'https://vimeo.com/123' }
   end
 end

--- a/spec/article_json/import/google_doc/embedded_youtube_video_element_spec.rb
+++ b/spec/article_json/import/google_doc/embedded_youtube_video_element_spec.rb
@@ -1,117 +1,53 @@
+require_relative 'embedded_element_shared'
+
 describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedYoutubeVideoElement do
-  subject(:element) do
-    described_class.new(
-      node: node,
-      caption_node: caption_node,
-      css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
-    )
-  end
-
-  let(:node) { Nokogiri::XML.fragment(html.strip) }
-  let(:html) do
-    <<-html
-      <p>
-        <span>
-          <a href="https://www.youtube.com/?v=#{video_id}">
-            https://www.youtube.com/?v=#{video_id}
-          </a>
-          <span>&nbsp;[youtube test]</span>
-        </span>
-      </p>
-    html
-  end
-
-  let(:caption_node) { Nokogiri::XML.fragment(caption_html.strip) }
-  let(:caption_html) { '<p><span>Caption</span></p>' }
-
-  let(:video_id) { '_ZG8HBuDjgc' }
-  let(:url_examples) do
-    %W(
-      http://youtu.be/#{video_id}?hl=en_US
-      http://www.youtube.com/embed/#{video_id}
-      http://www.youtube.com/watch?v=#{video_id}&hl=en_US
-      http://www.youtube.com/?v=#{video_id}
-      http://www.youtube.com/v/#{video_id}
-      http://www.youtube.com/e/#{video_id}
-      http://www.youtube.com/user/username#p/u/11/#{video_id}
-      http://www.youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{video_id}
-      http://www.youtube.com/watch?feature=player_embedded&v=#{video_id}&hl=en_US
-      http://www.youtube.com/?feature=player_embedded&v=#{video_id}
-      https://youtu.be/#{video_id}?hl=en_US
-      https://www.youtube.com/embed/#{video_id}
-      https://www.youtube.com/watch?v=#{video_id}&hl=en_US
-      https://www.youtube.com/?v=#{video_id}
-      https://www.youtube.com/v/#{video_id}
-      https://www.youtube.com/e/#{video_id}
-      https://www.youtube.com/user/username#p/u/11/#{video_id}
-      https://www.youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{video_id}
-      https://www.youtube.com/watch?feature=player_embedded&v=#{video_id}
-      https://www.youtube.com/?feature=player_embedded&v=#{video_id}
-      youtu.be/#{video_id}?hl=en_US
-      www.youtube.com/embed/#{video_id}
-      www.youtube.com/watch?v=#{video_id}&hl=en_US
-      www.youtube.com/?v=#{video_id}
-      www.youtube.com/v/#{video_id}
-      www.youtube.com/e/#{video_id}
-      www.youtube.com/user/username#p/u/11/#{video_id}
-      www.youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{video_id}
-      www.youtube.com/watch?feature=player_embedded&v=#{video_id}
-      www.youtube.com/?feature=player_embedded&v=#{video_id}
-      youtube.com/embed/#{video_id}
-      youtube.com/watch?v=#{video_id}&hl=en_US
-      youtube.com/?v=#{video_id}
-      youtube.com/v/#{video_id}
-      youtube.com/e/#{video_id}
-      youtube.com/user/username#p/u/11/#{video_id}
-      youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{video_id}
-      youtube.com/watch?feature=player_embedded&v=#{video_id}
-      youtube.com/?feature=player_embedded&v=#{video_id}
-    )
-  end
-
-  describe '#embed_type' do
-    subject { element.embed_type }
-    it { should eq :youtube_video }
-  end
-
-  describe '#embed_id' do
-    subject { element.embed_id }
-    it { should eq video_id }
-  end
-
-  describe 'to_h' do
-    subject { element.to_h }
-
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :embed
-      expect(subject[:embed_type]).to eq :youtube_video
-      expect(subject[:embed_id]).to eq video_id
-      expect(subject[:tags]).to match_array %w(youtube test)
-      expect(subject[:caption].first[:content]).to eq 'Caption'
-    end
-  end
-
-  describe '.matches?' do
-    subject { described_class.matches?(url) }
-
-    context 'when passed a text containing a Youtube URL' do
-      let(:url) { url_examples.sample }
-      it { should be true }
-    end
-
-    context 'when passed a text containing another URL' do
-      let(:url) { 'https://www.devex.com/news/youtube-videos-ftw-123' }
-      it { should be false }
-    end
-  end
-
-  describe '.url_regexp' do
-    subject { described_class.url_regexp }
-
-    it { should be_a Regexp }
-    it 'matches a lot of different Youtube URLs' do
-      url_examples.each { |url| expect(subject).to match url }
+  include_context 'for an embeddable object' do
+    let(:expected_embed_type) { :youtube_video }
+    let(:expected_embed_id) { '_ZG8HBuDjgc' }
+    let(:expected_tags) { %w(youtube test) }
+    let(:invalid_url_example) { 'https://www.devex.com/news/youtube-video-123' }
+    let(:url_examples) do
+      %W(
+        http://youtu.be/#{expected_embed_id}?hl=en_US
+        http://www.youtube.com/embed/#{expected_embed_id}
+        http://www.youtube.com/watch?v=#{expected_embed_id}&hl=en_US
+        http://www.youtube.com/?v=#{expected_embed_id}
+        http://www.youtube.com/v/#{expected_embed_id}
+        http://www.youtube.com/e/#{expected_embed_id}
+        http://www.youtube.com/user/username#p/u/11/#{expected_embed_id}
+        http://www.youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{expected_embed_id}
+        http://www.youtube.com/watch?feature=player_embedded&v=#{expected_embed_id}&hl=en_US
+        http://www.youtube.com/?feature=player_embedded&v=#{expected_embed_id}
+        https://youtu.be/#{expected_embed_id}?hl=en_US
+        https://www.youtube.com/embed/#{expected_embed_id}
+        https://www.youtube.com/watch?v=#{expected_embed_id}&hl=en_US
+        https://www.youtube.com/?v=#{expected_embed_id}
+        https://www.youtube.com/v/#{expected_embed_id}
+        https://www.youtube.com/e/#{expected_embed_id}
+        https://www.youtube.com/user/username#p/u/11/#{expected_embed_id}
+        https://www.youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{expected_embed_id}
+        https://www.youtube.com/watch?feature=player_embedded&v=#{expected_embed_id}
+        https://www.youtube.com/?feature=player_embedded&v=#{expected_embed_id}
+        youtu.be/#{expected_embed_id}?hl=en_US
+        www.youtube.com/embed/#{expected_embed_id}
+        www.youtube.com/watch?v=#{expected_embed_id}&hl=en_US
+        www.youtube.com/?v=#{expected_embed_id}
+        www.youtube.com/v/#{expected_embed_id}
+        www.youtube.com/e/#{expected_embed_id}
+        www.youtube.com/user/username#p/u/11/#{expected_embed_id}
+        www.youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{expected_embed_id}
+        www.youtube.com/watch?feature=player_embedded&v=#{expected_embed_id}
+        www.youtube.com/?feature=player_embedded&v=#{expected_embed_id}
+        youtube.com/embed/#{expected_embed_id}
+        youtube.com/watch?v=#{expected_embed_id}&hl=en_US
+        youtube.com/?v=#{expected_embed_id}
+        youtube.com/v/#{expected_embed_id}
+        youtube.com/e/#{expected_embed_id}
+        youtube.com/user/username#p/u/11/#{expected_embed_id}
+        youtube.com/sandalsResorts#p/c/54B8C800269D7C1B/0/#{expected_embed_id}
+        youtube.com/watch?feature=player_embedded&v=#{expected_embed_id}
+        youtube.com/?feature=player_embedded&v=#{expected_embed_id}
+      )
     end
   end
 end


### PR DESCRIPTION
As the behavior of the specs is identical, we can move most of the logic into a shared context.