### PR TITLE
Separate element definition and parsing: Image

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -18,7 +18,7 @@ require_relative 'article_json/import/google_doc/html/text_parser'
 require_relative 'article_json/import/google_doc/html/heading_parser'
 require_relative 'article_json/import/google_doc/html/paragraph_parser'
 require_relative 'article_json/import/google_doc/html/list_parser'
-require_relative 'article_json/import/google_doc/html/image_element'
+require_relative 'article_json/import/google_doc/html/image_parser'
 require_relative 'article_json/import/google_doc/html/text_box_element'
 require_relative 'article_json/import/google_doc/html/quote_element'
 

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -11,6 +11,7 @@ require_relative 'article_json/elements/text'
 require_relative 'article_json/elements/heading'
 require_relative 'article_json/elements/paragraph'
 require_relative 'article_json/elements/list'
+require_relative 'article_json/elements/image'
 
 require_relative 'article_json/import/google_doc/html/css_analyzer'
 require_relative 'article_json/import/google_doc/html/node_analyzer'

--- a/lib/article_json/elements/image.rb
+++ b/lib/article_json/elements/image.rb
@@ -1,0 +1,29 @@
+module ArticleJSON
+  module Elements
+    class Image
+      attr_reader :type, :source_url, :caption, :float
+
+      # @param [String] source_url
+      # @param [Array[ArticleJSON::Elements::Text]] caption
+      # @param [Symbol] float
+      def initialize(source_url:, caption:, float: nil)
+        @type = :image
+        @source_url = source_url
+        @caption = caption
+        @float = float
+      end
+
+      # Hash representation of this image element
+      # @return [Hash]
+      def to_h
+        {
+          type: type,
+          source_url: source_url,
+          float: float,
+          caption: caption.map(&:to_h),
+        }
+      end
+    end
+  end
+end
+

--- a/lib/article_json/import/google_doc/html/image_parser.rb
+++ b/lib/article_json/import/google_doc/html/image_parser.rb
@@ -2,7 +2,7 @@ module ArticleJSON
   module Import
     module GoogleDoc
       module HTML
-        class ImageElement
+        class ImageParser
           # @param [Nokogiri::HTML::Node] node
           # @param [Nokogiri::HTML::Node] caption_node
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer

--- a/lib/article_json/import/google_doc/html/image_parser.rb
+++ b/lib/article_json/import/google_doc/html/image_parser.rb
@@ -44,16 +44,13 @@ module ArticleJSON
             )
           end
 
-          # Hash representation of this image element
-          # @return [Hash]
-          def to_h
-            {
-              type: :image,
+          # @return [ArticleJSON::Elements::Image]
+          def element
+            ArticleJSON::Elements::Image.new(
               source_url: source_url,
               float: float,
-              original_width: image_width,
-              caption: caption.map(&:to_h),
-            }
+              caption: caption
+            )
           end
 
           private

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -67,9 +67,9 @@ module ArticleJSON
               .element
           end
 
-          # @return [ArticleJSON::Import::GoogleDoc::HTML::ImageElement]
+          # @return [ArticleJSON::Import::GoogleDoc::HTML::ImageParser]
           def parse_image
-            ImageElement.new(
+            ImageParser.new(
               node: @current_node.node,
               caption_node: @body_enumerator.next,
               css_analyzer: @css_analyzer

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -67,13 +67,15 @@ module ArticleJSON
               .element
           end
 
-          # @return [ArticleJSON::Import::GoogleDoc::HTML::ImageParser]
+          # @return [ArticleJSON::Elements::Image]
           def parse_image
-            ImageParser.new(
-              node: @current_node.node,
-              caption_node: @body_enumerator.next,
-              css_analyzer: @css_analyzer
-            )
+            ImageParser
+              .new(
+                node: @current_node.node,
+                caption_node: @body_enumerator.next,
+                css_analyzer: @css_analyzer
+              )
+              .element
           end
 
           # @return [ArticleJSON::Import::GoogleDoc::HTML::TextBoxElement]

--- a/spec/article_json/elements/image_spec.rb
+++ b/spec/article_json/elements/image_spec.rb
@@ -1,0 +1,11 @@
+describe ArticleJSON::Elements::Image do
+  subject(:element) { described_class.new(**params) }
+  let(:params) { { source_url: 'foo.jpg', caption: [caption], float: :left } }
+  let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+
+  describe '#to_h' do
+    subject { element.to_h }
+    it { should be_a Hash }
+    it { should eq params.merge(type: :image, caption: [caption.to_h]) }
+  end
+end

--- a/spec/article_json/import/google_doc/image_parser_spec.rb
+++ b/spec/article_json/import/google_doc/image_parser_spec.rb
@@ -151,15 +151,15 @@ describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
     end
   end
 
-  describe 'to_h' do
-    subject { element.to_h }
+  describe '#element' do
+    subject { element.element }
 
     it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :image
-      expect(subject[:source_url]).to eq source_url
-      expect(subject[:float]).to be nil
-      expect(subject[:caption]).to eq element.caption.map(&:to_h)
+      expect(subject).to be_a ArticleJSON::Elements::Image
+      expect(subject.type).to eq :image
+      expect(subject.source_url).to eq source_url
+      expect(subject.float).to be nil
+      expect(subject.caption).to all be_a ArticleJSON::Elements::Text
     end
   end
 end

--- a/spec/article_json/import/google_doc/image_parser_spec.rb
+++ b/spec/article_json/import/google_doc/image_parser_spec.rb
@@ -1,4 +1,4 @@
-describe ArticleJSON::Import::GoogleDoc::HTML::ImageElement do
+describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
   subject(:element) do
     described_class.new(
       node: node,

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -285,7 +285,6 @@
     "type": "image",
     "source_url": "https://lh6.googleusercontent.com/mddqDcb0cm8wTJCiXyllikOod1Ecsuyy1twC14rWwu41thuwrmQAYBkOmMPlC2a1mxB1ajaSew35FkoR_GOqXyj0lDWNpC45sapPfY1rzf9JihhMRV-G9MuSzMVkneMs4w",
     "float": "left",
-    "original_width": 294,
     "caption": [
       {
         "type": "text",
@@ -324,7 +323,6 @@
     "type": "image",
     "source_url": "https://lh3.googleusercontent.com/UIJGUBCt-DzS-Z4nwCKYfNektEGzLBotaBfmQQWYsA9dbgNsWEho3PpZOQRuN4KMpv8xd33OBawKjsIv5aOkd5onT_iq3eYEeBkP6QI-1uvFRKCqkpHm5lAnV-imj71-_Q",
     "float": "right",
-    "original_width": 336,
     "caption": [
       {
         "type": "text",
@@ -363,7 +361,6 @@
     "type": "image",
     "source_url": "https://lh4.googleusercontent.com/qos1DH9SdQKqHuLzz9P74aXYyfJMv2VAmDyjsytREUsQzwP4nshEnKitD64fk-1rq7Jo6OcPc4YM6fdMFUdiwnDruquYuhE6K3Fbi07HbymvpD51W2RiWR044suW4ZxKkw",
     "float": null,
-    "original_width": 588,
     "caption": [
       {
         "type": "text",


### PR DESCRIPTION
- Rename `ImageElement` to `ImageParser`
- Extract general stuff into element class that is supposed to be re-used by other import / export modules.
- Also removed the original image size, which was only used for debugging (therefore the parsed reference doc changed).