### PR TITLE
Separate element definition and parsing: Text box

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -20,7 +20,7 @@ require_relative 'article_json/import/google_doc/html/heading_parser'
 require_relative 'article_json/import/google_doc/html/paragraph_parser'
 require_relative 'article_json/import/google_doc/html/list_parser'
 require_relative 'article_json/import/google_doc/html/image_parser'
-require_relative 'article_json/import/google_doc/html/text_box_element'
+require_relative 'article_json/import/google_doc/html/text_box_parser'
 require_relative 'article_json/import/google_doc/html/quote_element'
 
 require_relative 'article_json/import/google_doc/html/embedded_element'

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -12,6 +12,7 @@ require_relative 'article_json/elements/heading'
 require_relative 'article_json/elements/paragraph'
 require_relative 'article_json/elements/list'
 require_relative 'article_json/elements/image'
+require_relative 'article_json/elements/text_box'
 
 require_relative 'article_json/import/google_doc/html/css_analyzer'
 require_relative 'article_json/import/google_doc/html/node_analyzer'

--- a/lib/article_json/elements/text_box.rb
+++ b/lib/article_json/elements/text_box.rb
@@ -1,0 +1,26 @@
+module ArticleJSON
+  module Elements
+    class TextBox
+      attr_reader :type, :content, :float
+
+      # @param [Array[Paragraph|Heading|List]] content
+      # @param [Symbol] float
+      def initialize(content:, float: nil)
+        @type = :text_box
+        @content = content
+        @float = float
+      end
+
+      # Hash representation of this text box element
+      # @return [Hash]
+      def to_h
+        {
+          type: type,
+          float: float,
+          content: content.map(&:to_h),
+        }
+      end
+    end
+  end
+end
+

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -78,13 +78,13 @@ module ArticleJSON
               .element
           end
 
-          # @return [ArticleJSON::Import::GoogleDoc::HTML::TextBoxElement]
+          # @return [ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser]
           def parse_text_box
             nodes = []
             until NodeAnalyzer.new(@body_enumerator.peek).hr?
               nodes << @body_enumerator.next
             end
-            TextBoxElement.new(nodes: nodes, css_analyzer: @css_analyzer)
+            TextBoxParser.new(nodes: nodes, css_analyzer: @css_analyzer)
           end
 
           # @return [ArticleJSON::Import::GoogleDoc::HTML::QuoteElement]

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -78,13 +78,13 @@ module ArticleJSON
               .element
           end
 
-          # @return [ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser]
+          # @return [ArticleJSON::Elements::TextBox]
           def parse_text_box
             nodes = []
             until NodeAnalyzer.new(@body_enumerator.peek).hr?
               nodes << @body_enumerator.next
             end
-            TextBoxParser.new(nodes: nodes, css_analyzer: @css_analyzer)
+            TextBoxParser.new(nodes: nodes, css_analyzer: @css_analyzer).element
           end
 
           # @return [ArticleJSON::Import::GoogleDoc::HTML::QuoteElement]

--- a/lib/article_json/import/google_doc/html/text_box_parser.rb
+++ b/lib/article_json/import/google_doc/html/text_box_parser.rb
@@ -2,7 +2,7 @@ module ArticleJSON
   module Import
     module GoogleDoc
       module HTML
-        class TextBoxElement
+        class TextBoxParser
           # @param [Array[Nokogiri::HTML::Node]] nodes
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
           def initialize(nodes:, css_analyzer:)

--- a/lib/article_json/import/google_doc/html/text_box_parser.rb
+++ b/lib/article_json/import/google_doc/html/text_box_parser.rb
@@ -28,13 +28,9 @@ module ArticleJSON
           end
 
           # Hash representation of this text box
-          # @return [Hash]
-          def to_h
-            {
-              type: :text_box,
-              float: float,
-              content: content.map(&:to_h),
-            }
+          # @return [ArticleJSON::Elements::TextBox]
+          def element
+            ArticleJSON::Elements::TextBox.new(float: float, content: content)
           end
 
           private

--- a/spec/article_json/elements/text_box_spec.rb
+++ b/spec/article_json/elements/text_box_spec.rb
@@ -1,0 +1,15 @@
+describe ArticleJSON::Elements::TextBox do
+  subject(:element) { described_class.new(**params) }
+  let(:params) { { content: [content], float: :right } }
+  let(:content) do
+    ArticleJSON::Elements::Paragraph.new(
+      content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
+    )
+  end
+
+  describe '#to_h' do
+    subject { element.to_h }
+    it { should be_a Hash }
+    it { should eq params.merge(type: :text_box, content: [content.to_h]) }
+  end
+end

--- a/spec/article_json/import/google_doc/text_box_parser_spec.rb
+++ b/spec/article_json/import/google_doc/text_box_parser_spec.rb
@@ -1,5 +1,5 @@
 describe ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser do
-  subject(:element) do
+  subject(:parser) do
     described_class.new(nodes: node.children, css_analyzer: css_analyzer)
   end
 
@@ -18,7 +18,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser do
   let(:css) { '' }
 
   describe '#float' do
-    subject { element.float }
+    subject { parser.float }
     context 'when the first node is centered' do
       let(:css) { '.css_class { text-align: center }' }
       it { should be nil }
@@ -35,7 +35,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser do
   end
 
   describe '#content' do
-    subject { element.content }
+    subject { parser.content }
 
     it 'returns a list of paragraph and heading elements' do
       expect(subject).to be_an Array
@@ -71,15 +71,17 @@ describe ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser do
     end
   end
 
-  describe '#to_h' do
-    subject { element.to_h }
+  describe '#element' do
+    subject { parser.element }
 
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :text_box
-      expect(subject[:float]).to eq :left
-      expect(subject[:content]).to be_an Array
-      expect(subject[:content]).to all be_a Hash
+    it 'returns a proper text box element' do
+      expect(subject).to be_a ArticleJSON::Elements::TextBox
+      expect(subject.type).to eq :text_box
+      expect(subject.float).to eq :left
+      expect(subject.content).to be_an Array
+      expect(subject.content[0]).to be_a ArticleJSON::Elements::Heading
+      expect(subject.content[1]).to be_a ArticleJSON::Elements::Paragraph
+      expect(subject.content[2]).to be_a ArticleJSON::Elements::Paragraph
     end
   end
 end

--- a/spec/article_json/import/google_doc/text_box_parser_spec.rb
+++ b/spec/article_json/import/google_doc/text_box_parser_spec.rb
@@ -1,4 +1,4 @@
-describe ArticleJSON::Import::GoogleDoc::HTML::TextBoxElement do
+describe ArticleJSON::Import::GoogleDoc::HTML::TextBoxParser do
   subject(:element) do
     described_class.new(nodes: node.children, css_analyzer: css_analyzer)
   end


### PR DESCRIPTION
- Rename `TextBoxElement` to `TextBoxParser`
- Extract general stuff into element class that is supposed to be re-used by other import / export modules.