### PR TITLE
Separate element definition and parsing: Quote

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -13,6 +13,7 @@ require_relative 'article_json/elements/paragraph'
 require_relative 'article_json/elements/list'
 require_relative 'article_json/elements/image'
 require_relative 'article_json/elements/text_box'
+require_relative 'article_json/elements/quote'
 
 require_relative 'article_json/import/google_doc/html/css_analyzer'
 require_relative 'article_json/import/google_doc/html/node_analyzer'

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -22,7 +22,7 @@ require_relative 'article_json/import/google_doc/html/paragraph_parser'
 require_relative 'article_json/import/google_doc/html/list_parser'
 require_relative 'article_json/import/google_doc/html/image_parser'
 require_relative 'article_json/import/google_doc/html/text_box_parser'
-require_relative 'article_json/import/google_doc/html/quote_element'
+require_relative 'article_json/import/google_doc/html/quote_parser'
 
 require_relative 'article_json/import/google_doc/html/embedded_element'
 require_relative 'article_json/import/google_doc/html/embedded_facebook_video_element'

--- a/lib/article_json/elements/quote.rb
+++ b/lib/article_json/elements/quote.rb
@@ -1,0 +1,29 @@
+module ArticleJSON
+  module Elements
+    class Quote
+      attr_reader :type, :content, :caption, :float
+
+      # @param [Array[ArticleJSON::Elements::Paragraph]] content
+      # @param [Array[ArticleJSON::Elements::Text]] caption
+      # @param [Symbol] float
+      def initialize(content:, caption:, float: nil)
+        @type = :quote
+        @content = content
+        @caption = caption
+        @float = float
+      end
+
+      # Hash representation of this quote element
+      # @return [Hash]
+      def to_h
+        {
+          type: type,
+          float: float,
+          content: content.map(&:to_h),
+          caption: caption.map(&:to_h),
+        }
+      end
+    end
+  end
+end
+

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -87,13 +87,13 @@ module ArticleJSON
             TextBoxParser.new(nodes: nodes, css_analyzer: @css_analyzer).element
           end
 
-          # @return [ArticleJSON::Import::GoogleDoc::HTML::QuoteElement]
+          # @return [ArticleJSON::Import::GoogleDoc::HTML::QuoteParser]
           def parse_quote
             nodes = []
             until NodeAnalyzer.new(@body_enumerator.peek).hr?
               nodes << @body_enumerator.next
             end
-            QuoteElement.new(nodes: nodes, css_analyzer: @css_analyzer)
+            QuoteParser.new(nodes: nodes, css_analyzer: @css_analyzer)
           end
 
           # @return [ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement]

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -87,13 +87,13 @@ module ArticleJSON
             TextBoxParser.new(nodes: nodes, css_analyzer: @css_analyzer).element
           end
 
-          # @return [ArticleJSON::Import::GoogleDoc::HTML::QuoteParser]
+          # @return [ArticleJSON::Elements::Quote]
           def parse_quote
             nodes = []
             until NodeAnalyzer.new(@body_enumerator.peek).hr?
               nodes << @body_enumerator.next
             end
-            QuoteParser.new(nodes: nodes, css_analyzer: @css_analyzer)
+            QuoteParser.new(nodes: nodes, css_analyzer: @css_analyzer).element
           end
 
           # @return [ArticleJSON::Import::GoogleDoc::HTML::EmbeddedElement]

--- a/lib/article_json/import/google_doc/html/quote_parser.rb
+++ b/lib/article_json/import/google_doc/html/quote_parser.rb
@@ -2,7 +2,7 @@ module ArticleJSON
   module Import
     module GoogleDoc
       module HTML
-        class QuoteElement
+        class QuoteParser
           # @param [Array[Nokogiri::HTML::Node]] nodes
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
           def initialize(nodes:, css_analyzer:)

--- a/lib/article_json/import/google_doc/html/quote_parser.rb
+++ b/lib/article_json/import/google_doc/html/quote_parser.rb
@@ -22,7 +22,7 @@ module ArticleJSON
 
           # Parse the quote's nodes to get a set of paragraphs
           # The last node is ignored as it contains the quote caption
-          # @return [Array]
+          # @return [Array[ArticleJSON::Elements::Paragraph]]
           def content
             @nodes
               .take(@nodes.size - 1)
@@ -39,15 +39,13 @@ module ArticleJSON
             TextParser.extract(node: @nodes.last, css_analyzer: @css_analyzer)
           end
 
-          # Hash representation of this quote
-          # @return [Hash]
-          def to_h
-            {
-              type: :quote,
-              float: float,
-              content: content.map(&:to_h),
-              caption: caption.map(&:to_h),
-            }
+          # @return [ArticleJSON::Elements::Quote]
+          def element
+            ArticleJSON::Elements::Quote.new(
+              content: content,
+              caption: caption,
+              float: float
+            )
           end
         end
       end

--- a/spec/article_json/elements/quote_spec.rb
+++ b/spec/article_json/elements/quote_spec.rb
@@ -1,0 +1,25 @@
+describe ArticleJSON::Elements::Quote do
+  subject(:element) { described_class.new(**params) }
+  let(:params) { { content: [content], caption: [caption], float: :left } }
+  let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:content) do
+    ArticleJSON::Elements::Paragraph.new(
+      content: [ArticleJSON::Elements::Text.new(content: 'Bar Baz')]
+    )
+  end
+
+  describe '#to_h' do
+    subject { element.to_h }
+    let(:expected_hash) do
+      {
+        type: :quote,
+        content: [content.to_h],
+        caption: [caption.to_h],
+        float: :left,
+      }
+    end
+
+    it { should be_a Hash }
+    it { should eq expected_hash }
+  end
+end

--- a/spec/article_json/import/google_doc/quote_parser_spec.rb
+++ b/spec/article_json/import/google_doc/quote_parser_spec.rb
@@ -1,5 +1,5 @@
 describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
-  subject(:element) do
+  subject(:parser) do
     described_class.new(nodes: node.children, css_analyzer: css_analyzer)
   end
 
@@ -19,7 +19,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
   let(:css) { '' }
 
   describe '#float' do
-    subject { element.float }
+    subject { parser.float }
     context 'when the first node is centered' do
       let(:css) { '.css_class { text-align: center }' }
       it { should be nil }
@@ -36,7 +36,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
   end
 
   describe '#content' do
-    subject { element.content }
+    subject { parser.content }
 
     it 'returns a list of paragraph and heading elements' do
       expect(subject).to be_an Array
@@ -48,7 +48,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
   end
 
   describe '#caption' do
-    subject { element.caption }
+    subject { parser.caption }
 
     it 'returns a list of text elements' do
       expect(subject).to be_an Array
@@ -60,17 +60,17 @@ describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
     end
   end
 
-  describe '#to_h' do
-    subject { element.to_h }
+  describe '#element' do
+    subject { parser.element }
 
-    it 'returns a proper Hash' do
-      expect(subject).to be_a Hash
-      expect(subject[:type]).to eq :quote
-      expect(subject[:float]).to be :left
-      expect(subject[:content]).to be_an Array
-      expect(subject[:content]).to all be_a Hash
-      expect(subject[:caption]).to be_an Array
-      expect(subject[:caption]).to all be_a Hash
+    it 'returns a proper quote element' do
+      expect(subject).to be_a ArticleJSON::Elements::Quote
+      expect(subject.type).to eq :quote
+      expect(subject.float).to be :left
+      expect(subject.content).to be_an Array
+      expect(subject.content).to all be_a ArticleJSON::Elements::Paragraph
+      expect(subject.caption).to be_an Array
+      expect(subject.caption).to all be_a ArticleJSON::Elements::Text
     end
   end
 end

--- a/spec/article_json/import/google_doc/quote_parser_spec.rb
+++ b/spec/article_json/import/google_doc/quote_parser_spec.rb
@@ -1,4 +1,4 @@
-describe ArticleJSON::Import::GoogleDoc::HTML::QuoteElement do
+describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
   subject(:element) do
     described_class.new(nodes: node.children, css_analyzer: css_analyzer)
   end


### PR DESCRIPTION

- Rename `QuoteElement` to `QuoteParser`
- Extract general stuff into element class that is supposed to be re-used by other import / export modules.