### PR TITLE
Code improvements

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -16,6 +16,7 @@ require_relative 'article_json/elements/text_box'
 require_relative 'article_json/elements/quote'
 require_relative 'article_json/elements/embed'
 
+require_relative 'article_json/import/google_doc/html/shared/caption'
 require_relative 'article_json/import/google_doc/html/css_analyzer'
 require_relative 'article_json/import/google_doc/html/node_analyzer'
 require_relative 'article_json/import/google_doc/html/text_parser'

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -17,6 +17,8 @@ require_relative 'article_json/elements/quote'
 require_relative 'article_json/elements/embed'
 
 require_relative 'article_json/import/google_doc/html/shared/caption'
+require_relative 'article_json/import/google_doc/html/shared/float'
+
 require_relative 'article_json/import/google_doc/html/css_analyzer'
 require_relative 'article_json/import/google_doc/html/node_analyzer'
 require_relative 'article_json/import/google_doc/html/text_parser'

--- a/lib/article_json/import/google_doc/html/embedded_parser.rb
+++ b/lib/article_json/import/google_doc/html/embedded_parser.rb
@@ -3,6 +3,8 @@ module ArticleJSON
     module GoogleDoc
       module HTML
         class EmbeddedParser
+          include Shared::Caption
+
           # @param [Nokogiri::HTML::Node] node
           # @param [Nokogiri::HTML::Node] caption_node
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
@@ -31,15 +33,6 @@ module ArticleJSON
           def tags
             match = /(.*?)[\s\u00A0]+\[(?<tags>.*)\]/.match(@node.inner_text)
             (match ? match[:tags] : '').split(' ')
-          end
-
-          # Parse the embed's caption node
-          # @return [Array[ArticleJSON::Elements::Text]]
-          def caption
-            TextParser.extract(
-              node: @caption_node,
-              css_analyzer: @css_analyzer
-            )
           end
 
           # The embedded element

--- a/lib/article_json/import/google_doc/html/image_parser.rb
+++ b/lib/article_json/import/google_doc/html/image_parser.rb
@@ -3,6 +3,8 @@ module ArticleJSON
     module GoogleDoc
       module HTML
         class ImageParser
+          include Shared::Caption
+
           # @param [Nokogiri::HTML::Node] node
           # @param [Nokogiri::HTML::Node] caption_node
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
@@ -34,14 +36,6 @@ module ArticleJSON
             return :left if @css_analyzer.left_aligned?(node_class)
 
             nil
-          end
-
-          # @return [Array[ArticleJSON::Elements::Text]]
-          def caption
-            TextParser.extract(
-              node: @caption_node,
-              css_analyzer: @css_analyzer
-            )
           end
 
           # @return [ArticleJSON::Elements::Image]

--- a/lib/article_json/import/google_doc/html/image_parser.rb
+++ b/lib/article_json/import/google_doc/html/image_parser.rb
@@ -4,6 +4,7 @@ module ArticleJSON
       module HTML
         class ImageParser
           include Shared::Caption
+          include Shared::Float
 
           # @param [Nokogiri::HTML::Node] node
           # @param [Nokogiri::HTML::Node] caption_node
@@ -12,6 +13,9 @@ module ArticleJSON
             @node = node
             @caption_node = caption_node
             @css_analyzer = css_analyzer
+
+            # Main node indicates the floating behavior
+            @float_node = @node
           end
 
           # The value of the image's `src` attribute
@@ -29,13 +33,7 @@ module ArticleJSON
           # Check if the image is floating (left, right or not at all)
           # @return [Symbol]
           def float
-            return unless floatable_size? && @node.has_attribute?('class')
-
-            node_class = @node.attribute('class').value
-            return :right if @css_analyzer.right_aligned?(node_class)
-            return :left if @css_analyzer.left_aligned?(node_class)
-
-            nil
+            super if floatable_size?
           end
 
           # @return [ArticleJSON::Elements::Image]

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -80,20 +80,16 @@ module ArticleJSON
 
           # @return [ArticleJSON::Elements::TextBox]
           def parse_text_box
-            nodes = []
-            until NodeAnalyzer.new(@body_enumerator.peek).hr?
-              nodes << @body_enumerator.next
-            end
-            TextBoxParser.new(nodes: nodes, css_analyzer: @css_analyzer).element
+            TextBoxParser
+              .new(nodes: nodes_until_hr, css_analyzer: @css_analyzer)
+              .element
           end
 
           # @return [ArticleJSON::Elements::Quote]
           def parse_quote
-            nodes = []
-            until NodeAnalyzer.new(@body_enumerator.peek).hr?
-              nodes << @body_enumerator.next
-            end
-            QuoteParser.new(nodes: nodes, css_analyzer: @css_analyzer).element
+            QuoteParser
+              .new(nodes: nodes_until_hr, css_analyzer: @css_analyzer)
+              .element
           end
 
           # @return [ArticleJSON::Elements::Embed]
@@ -103,6 +99,16 @@ module ArticleJSON
               caption_node: @body_enumerator.next,
               css_analyzer: @css_analyzer
             )
+          end
+
+          # Collect all nodes until a horizontal line, advancing the enumerator
+          # @return [Array[Nokogiri::HTML::Node]]
+          def nodes_until_hr
+            nodes = []
+            until NodeAnalyzer.new(@body_enumerator.peek).hr?
+              nodes << @body_enumerator.next
+            end
+            nodes
           end
 
           # @return [Boolean]

--- a/lib/article_json/import/google_doc/html/quote_parser.rb
+++ b/lib/article_json/import/google_doc/html/quote_parser.rb
@@ -4,23 +4,18 @@ module ArticleJSON
       module HTML
         class QuoteParser
           include Shared::Caption
+          include Shared::Float
 
           # @param [Array[Nokogiri::HTML::Node]] nodes
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
           def initialize(nodes:, css_analyzer:)
             @nodes = nodes.reject { |node| NodeAnalyzer.new(node).empty? }
-            @caption_node = @nodes.last
             @css_analyzer = css_analyzer
-          end
 
-          # Check if the quote is floating (left, right or not at all)
-          # The first paragraph of the quote indicates its floating value.
-          # @return [Symbol]
-          def float
-            node_class = @nodes.first.attribute('class')&.value || ''
-            return :right if @css_analyzer.right_aligned?(node_class)
-            return :left if @css_analyzer.left_aligned?(node_class)
-            nil
+            # First node of the quote indicates floating behavior
+            @float_node = @nodes.first
+            # Last node of the quote contains the caption
+            @caption_node = @nodes.last
           end
 
           # Parse the quote's nodes to get a set of paragraphs

--- a/lib/article_json/import/google_doc/html/quote_parser.rb
+++ b/lib/article_json/import/google_doc/html/quote_parser.rb
@@ -3,10 +3,13 @@ module ArticleJSON
     module GoogleDoc
       module HTML
         class QuoteParser
+          include Shared::Caption
+
           # @param [Array[Nokogiri::HTML::Node]] nodes
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
           def initialize(nodes:, css_analyzer:)
             @nodes = nodes.reject { |node| NodeAnalyzer.new(node).empty? }
+            @caption_node = @nodes.last
             @css_analyzer = css_analyzer
           end
 
@@ -31,12 +34,6 @@ module ArticleJSON
                   .new(node: node, css_analyzer: @css_analyzer)
                   .element
               end
-          end
-
-          # Parse the quote's last node to get the caption
-          # @return [Array[ArticleJSON::Elements::Text]]
-          def caption
-            TextParser.extract(node: @nodes.last, css_analyzer: @css_analyzer)
           end
 
           # @return [ArticleJSON::Elements::Quote]

--- a/lib/article_json/import/google_doc/html/shared/caption.rb
+++ b/lib/article_json/import/google_doc/html/shared/caption.rb
@@ -1,0 +1,20 @@
+module ArticleJSON
+  module Import
+    module GoogleDoc
+      module HTML
+        module Shared
+          module Caption
+            # Parse the caption node
+            # @return [Array[ArticleJSON::Elements::Text]]
+            def caption
+              ArticleJSON::Import::GoogleDoc::HTML::TextParser.extract(
+                node: @caption_node,
+                css_analyzer: @css_analyzer
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/import/google_doc/html/shared/float.rb
+++ b/lib/article_json/import/google_doc/html/shared/float.rb
@@ -1,0 +1,21 @@
+module ArticleJSON
+  module Import
+    module GoogleDoc
+      module HTML
+        module Shared
+          module Float
+            # Check if the quote is floating (left, right or not at all)
+            # @return [Symbol]
+            def float
+              return unless @float_node.has_attribute?('class')
+              node_class = @float_node.attribute('class').value || ''
+              return :right if @css_analyzer.right_aligned?(node_class)
+              return :left if @css_analyzer.left_aligned?(node_class)
+              nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/import/google_doc/html/text_box_parser.rb
+++ b/lib/article_json/import/google_doc/html/text_box_parser.rb
@@ -3,21 +3,16 @@ module ArticleJSON
     module GoogleDoc
       module HTML
         class TextBoxParser
+          include Shared::Float
+
           # @param [Array[Nokogiri::HTML::Node]] nodes
           # @param [ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer] css_analyzer
           def initialize(nodes:, css_analyzer:)
             @nodes = nodes.reject { |node| NodeAnalyzer.new(node).empty? }
             @css_analyzer = css_analyzer
-          end
 
-          # Check if the text box is floating (left, right or not at all)
-          # The first paragraph of the text box indicates its floating value.
-          # @return [Symbol]
-          def float
-            node_class = @nodes.first.attribute('class')&.value || ''
-            return :right if @css_analyzer.right_aligned?(node_class)
-            return :left if @css_analyzer.left_aligned?(node_class)
-            nil
+            # First node of the text box indicates floating behavior
+            @float_node = @nodes.first
           end
 
           # Parse the text box's nodes to get a list of sub elements


### PR DESCRIPTION
- Extract `#float` and `#caption` methods: Several parsers support captions or floating, so the functionality can be shared among them via module...
- Extract the logic of collecting all nodes until a `<hr>` while advancing the enumerator into its own method.