### PR TITLE
Implement parsing of hashes

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -7,6 +7,7 @@ require 'css_parser'
 
 require_relative 'article_json/version'
 
+require_relative 'article_json/elements/base'
 require_relative 'article_json/elements/text'
 require_relative 'article_json/elements/heading'
 require_relative 'article_json/elements/paragraph'
@@ -18,7 +19,6 @@ require_relative 'article_json/elements/embed'
 
 require_relative 'article_json/import/google_doc/html/shared/caption'
 require_relative 'article_json/import/google_doc/html/shared/float'
-
 require_relative 'article_json/import/google_doc/html/css_analyzer'
 require_relative 'article_json/import/google_doc/html/node_analyzer'
 require_relative 'article_json/import/google_doc/html/text_parser'
@@ -28,12 +28,10 @@ require_relative 'article_json/import/google_doc/html/list_parser'
 require_relative 'article_json/import/google_doc/html/image_parser'
 require_relative 'article_json/import/google_doc/html/text_box_parser'
 require_relative 'article_json/import/google_doc/html/quote_parser'
-
 require_relative 'article_json/import/google_doc/html/embedded_parser'
 require_relative 'article_json/import/google_doc/html/embedded_facebook_video_parser'
 require_relative 'article_json/import/google_doc/html/embedded_vimeo_video_parser'
 require_relative 'article_json/import/google_doc/html/embedded_youtube_video_parser'
 require_relative 'article_json/import/google_doc/html/embedded_slideshare_parser'
 require_relative 'article_json/import/google_doc/html/embedded_tweet_parser'
-
 require_relative 'article_json/import/google_doc/html/parser'

--- a/lib/article_json/elements/base.rb
+++ b/lib/article_json/elements/base.rb
@@ -1,0 +1,40 @@
+module ArticleJSON
+  module Elements
+    class Base
+      attr_reader :type
+
+      class << self
+        # Create an element from a hash, based on the :type field
+        # @param [Hash] hash
+        # @return [ArticleJSON::Elements::Base]
+        def parse_hash(hash)
+          klass = element_classes[hash[:type].to_sym]
+          klass.parse_hash(hash) unless klass.nil?
+        end
+
+        # Create a list of elements from an array of hashes
+        # @param [Array[Hash]] hash_list
+        # @return [Array[ArticleJSON::Elements::Base]]
+        def parse_hash_list(hash_list)
+          hash_list.map { |hash| Base.parse_hash(hash) }.compact
+        end
+
+        private
+
+        def element_classes
+          {
+            embed: Embed,
+            heading: Heading,
+            image: Image,
+            list: List,
+            paragraph: Paragraph,
+            quote: Quote,
+            text: Text,
+            text_box: TextBox,
+          }
+        end
+      end
+    end
+  end
+end
+

--- a/lib/article_json/elements/embed.rb
+++ b/lib/article_json/elements/embed.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class Embed
-      attr_reader :type, :embed_type, :embed_id, :caption, :tags
+    class Embed < Base
+      attr_reader :embed_type, :embed_id, :caption, :tags
 
       # @param [Symbol] embed_type
       # @param [String] embed_id
@@ -25,6 +25,19 @@ module ArticleJSON
           tags: tags,
           caption: caption.map(&:to_h),
         }
+      end
+
+      class << self
+        # Create an embedded element from Hash
+        # @return [ArticleJSON::Elements::Embed]
+        def parse_hash(hash)
+          new(
+            embed_type: hash[:embed_type],
+            embed_id: hash[:embed_id],
+            caption: parse_hash_list(hash[:caption]),
+            tags: hash[:tags]
+          )
+        end
       end
     end
   end

--- a/lib/article_json/elements/heading.rb
+++ b/lib/article_json/elements/heading.rb
@@ -1,7 +1,8 @@
 module ArticleJSON
   module Elements
-    class Heading
-      attr_reader :type, :level, :content
+    class Heading < Base
+      attr_reader :level, :content
+
       # @param [String] level
       # @param [String] content
       def initialize(level:, content:)
@@ -18,6 +19,17 @@ module ArticleJSON
           level: level,
           content: content,
         }
+      end
+
+      class << self
+        # Create a heading element from Hash
+        # @return [ArticleJSON::Elements::Heading]
+        def parse_hash(hash)
+          new(
+            level: hash[:level].to_i,
+            content: hash[:content]
+          )
+        end
       end
     end
   end

--- a/lib/article_json/elements/image.rb
+++ b/lib/article_json/elements/image.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class Image
-      attr_reader :type, :source_url, :caption, :float
+    class Image < Base
+      attr_reader :source_url, :caption, :float
 
       # @param [String] source_url
       # @param [Array[ArticleJSON::Elements::Text]] caption
@@ -22,6 +22,18 @@ module ArticleJSON
           float: float,
           caption: caption.map(&:to_h),
         }
+      end
+
+      class << self
+        # Create a image element from Hash
+        # @return [ArticleJSON::Elements::Image]
+        def parse_hash(hash)
+          new(
+            source_url: hash[:source_url],
+            caption: parse_hash_list(hash[:caption]),
+            float: hash[:float]&.to_sym
+          )
+        end
       end
     end
   end

--- a/lib/article_json/elements/list.rb
+++ b/lib/article_json/elements/list.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class List
-      attr_reader :type, :content, :list_type
+    class List < Base
+      attr_reader :content, :list_type
 
       # @param [Array[ArticleJSON::Elements::Paragraph]] content
       # @param [Symbol] list_type
@@ -19,6 +19,17 @@ module ArticleJSON
           list_type: list_type,
           content: content.map(&:to_h),
         }
+      end
+
+      class << self
+        # Create a list element from Hash
+        # @return [ArticleJSON::Elements::List]
+        def parse_hash(hash)
+          new(
+            content: parse_hash_list(hash[:content]),
+            list_type: hash[:list_type].to_sym
+          )
+        end
       end
     end
   end

--- a/lib/article_json/elements/paragraph.rb
+++ b/lib/article_json/elements/paragraph.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class Paragraph
-      attr_reader :type, :content
+    class Paragraph < Base
+      attr_reader :content
 
       # @param [Array[ArticleJSON::Elements::Text]] content
       def initialize(content:)
@@ -16,6 +16,14 @@ module ArticleJSON
           type: type,
           content: content.map(&:to_h),
         }
+      end
+
+      class << self
+        # Create a paragraph element from Hash
+        # @return [ArticleJSON::Elements::Paragraph]
+        def parse_hash(hash)
+          new(content: parse_hash_list(hash[:content]))
+        end
       end
     end
   end

--- a/lib/article_json/elements/quote.rb
+++ b/lib/article_json/elements/quote.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class Quote
-      attr_reader :type, :content, :caption, :float
+    class Quote < Base
+      attr_reader :content, :caption, :float
 
       # @param [Array[ArticleJSON::Elements::Paragraph]] content
       # @param [Array[ArticleJSON::Elements::Text]] caption
@@ -22,6 +22,18 @@ module ArticleJSON
           content: content.map(&:to_h),
           caption: caption.map(&:to_h),
         }
+      end
+
+      class << self
+        # Create a quote element from Hash
+        # @return [ArticleJSON::Elements::Quote]
+        def parse_hash(hash)
+          new(
+            content: parse_hash_list(hash[:content]),
+            caption: parse_hash_list(hash[:caption]),
+            float: hash[:float]&.to_sym
+          )
+        end
       end
     end
   end

--- a/lib/article_json/elements/text.rb
+++ b/lib/article_json/elements/text.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class Text
-      attr_reader :type, :content, :bold, :italic, :href
+    class Text < Base
+      attr_reader :content, :bold, :italic, :href
 
       # @param [String] content
       # @param [Boolean] bold
@@ -25,6 +25,19 @@ module ArticleJSON
           italic: italic,
           href: href,
         }
+      end
+
+      class << self
+        # Create a text element from Hash
+        # @return [ArticleJSON::Elements::Text]
+        def parse_hash(hash)
+          new(
+            content: hash[:content],
+            bold: hash[:bold],
+            italic: hash[:italic],
+            href: hash[:href]
+          )
+        end
       end
     end
   end

--- a/lib/article_json/elements/text_box.rb
+++ b/lib/article_json/elements/text_box.rb
@@ -1,7 +1,7 @@
 module ArticleJSON
   module Elements
-    class TextBox
-      attr_reader :type, :content, :float
+    class TextBox < Base
+      attr_reader :content, :float
 
       # @param [Array[Paragraph|Heading|List]] content
       # @param [Symbol] float
@@ -19,6 +19,17 @@ module ArticleJSON
           float: float,
           content: content.map(&:to_h),
         }
+      end
+
+      class << self
+        # Create a text box element from Hash
+        # @return [ArticleJSON::Elements::TextBox]
+        def parse_hash(hash)
+          new(
+            content: parse_hash_list(hash[:content]),
+            float: hash[:float]&.to_sym
+          )
+        end
       end
     end
   end

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -13,7 +13,7 @@ module ArticleJSON
           end
 
           # Parse the body of the document and return the result
-          # @return [Array]
+          # @return [Array[ArticleJSON::Elements::Base]]
           def parsed_content
             @parsed_content ||= parse_body
           end
@@ -21,7 +21,7 @@ module ArticleJSON
           private
 
           # Loop over all body nodes and parse them
-          # @return [Array]
+          # @return [Array[ArticleJSON::Elements::Base]]
           def parse_body
             @parsed_content = []
             while body_has_more_nodes?
@@ -34,7 +34,7 @@ module ArticleJSON
           end
 
           # Parse the current node and return an element, if available
-          # @return [Object]
+          # @return [ArticleJSON::Elements::Base]
           def parse_current_node
             case @current_node.type
             when :heading then parse_heading

--- a/spec/article_json/elements/base_spec.rb
+++ b/spec/article_json/elements/base_spec.rb
@@ -1,0 +1,112 @@
+describe ArticleJSON::Elements::Base do
+  let(:text_hash) do
+    { type: :text, content: 'Foobar', bold: true, italic: true, href: '/foo' }
+  end
+  let(:heading_hash) { { type: :heading, level: 42, content: 'Foobar' } }
+  let(:paragraph_hash) { { type: :paragraph, content: [text_hash] } }
+  let(:list_hash) do
+    { type: :list, content: [paragraph_hash], list_type: :ordered }
+  end
+  let(:image_hash) { { type: :image, caption: [text_hash], float: :right } }
+  let(:text_box_hash) do
+    { type: :text_box, content: [paragraph_hash], float: :right }
+  end
+  let(:quote_hash) do
+    {
+      type: :quote,
+      content: [paragraph_hash],
+      caption: [text_hash],
+      float: :left
+    }
+  end
+  let(:embed_hash) do
+    {
+      type: :embed,
+      embed_type: :something,
+      embed_id: '666',
+      caption: [text_hash],
+      tags: %w(foo bar)
+    }
+  end
+
+  describe '.parse_hash'do
+    subject { described_class.parse_hash(hash) }
+
+    context 'when the hash is a text' do
+      let(:hash) { text_hash }
+      it { should be_a ArticleJSON::Elements::Text }
+    end
+
+    context 'when the hash is a heading' do
+      let(:hash) { heading_hash }
+      it { should be_a ArticleJSON::Elements::Heading }
+    end
+
+    context 'when the hash is a paragraph' do
+      let(:hash) { paragraph_hash }
+      it { should be_a ArticleJSON::Elements::Paragraph }
+    end
+
+    context 'when the hash is a list' do
+      let(:hash) { list_hash }
+      it { should be_a ArticleJSON::Elements::List }
+    end
+
+    context 'when the hash is a image' do
+      let(:hash) { image_hash }
+      it { should be_a ArticleJSON::Elements::Image }
+    end
+
+    context 'when the hash is a text box' do
+      let(:hash) { text_box_hash }
+      it { should be_a ArticleJSON::Elements::TextBox }
+    end
+
+    context 'when the hash is a quote' do
+      let(:hash) { quote_hash }
+      it { should be_a ArticleJSON::Elements::Quote }
+    end
+
+    context 'when the hash is a embed' do
+      let(:hash) { embed_hash }
+      it { should be_a ArticleJSON::Elements::Embed }
+    end
+  end
+
+  describe '.parse_hash_list' do
+    subject { described_class.parse_hash_list(list) }
+    let(:list) do
+      [
+        text_hash,
+        heading_hash,
+        paragraph_hash,
+        list_hash,
+        image_hash,
+        text_box_hash,
+        quote_hash,
+        embed_hash
+      ]
+    end
+
+    it { should be_an Array }
+    it 'should have the correct elements' do
+      expect(subject[0]).to be_a ArticleJSON::Elements::Text
+      expect(subject[1]).to be_a ArticleJSON::Elements::Heading
+      expect(subject[2]).to be_a ArticleJSON::Elements::Paragraph
+      expect(subject[3]).to be_a ArticleJSON::Elements::List
+      expect(subject[4]).to be_a ArticleJSON::Elements::Image
+      expect(subject[5]).to be_a ArticleJSON::Elements::TextBox
+      expect(subject[6]).to be_a ArticleJSON::Elements::Quote
+      expect(subject[7]).to be_a ArticleJSON::Elements::Embed
+    end
+  end
+
+  describe 'reference document test' do
+    let(:json) { File.read('spec/fixtures/reference_document_parsed.json') }
+    let(:parsed_json) { JSON.parse(json, symbolize_names: true) }
+
+    subject { described_class.parse_hash_list(parsed_json).map(&:to_h).to_json }
+
+    it { should eq parsed_json.to_json }
+  end
+end

--- a/spec/article_json/elements/embed_spec.rb
+++ b/spec/article_json/elements/embed_spec.rb
@@ -9,10 +9,22 @@ describe ArticleJSON::Elements::Embed do
     }
   end
   let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:hash) { params.merge(type: :embed, caption: [caption.to_h]) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :embed, caption: [caption.to_h]) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::Embed }
+    it 'has the correct values' do
+      expect(subject.caption).to all be_a ArticleJSON::Elements::Text
+      expect(subject.embed_type).to eq hash[:embed_type]
+      expect(subject.embed_id).to eq hash[:embed_id]
+      expect(subject.tags).to eq hash[:tags]
+    end
   end
 end

--- a/spec/article_json/elements/heading_spec.rb
+++ b/spec/article_json/elements/heading_spec.rb
@@ -1,10 +1,20 @@
 describe ArticleJSON::Elements::Heading do
   subject(:element) { described_class.new(**params) }
   let(:params) { { level: 42, content: 'Foobar' } }
+  let(:hash) { params.merge(type: :heading) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :heading) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::Heading }
+    it 'has the correct values' do
+      expect(subject.level).to eq hash[:level]
+      expect(subject.content).to eq hash[:content]
+    end
   end
 end

--- a/spec/article_json/elements/image_spec.rb
+++ b/spec/article_json/elements/image_spec.rb
@@ -2,10 +2,21 @@ describe ArticleJSON::Elements::Image do
   subject(:element) { described_class.new(**params) }
   let(:params) { { source_url: 'foo.jpg', caption: [caption], float: :left } }
   let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:hash) { params.merge(type: :image, caption: [caption.to_h]) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :image, caption: [caption.to_h]) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::Image }
+    it 'has the correct values' do
+      expect(subject.source_url).to eq hash[:source_url]
+      expect(subject.float).to eq hash[:float]
+      expect(subject.caption).to all be_a ArticleJSON::Elements::Text
+    end
   end
 end

--- a/spec/article_json/elements/list_spec.rb
+++ b/spec/article_json/elements/list_spec.rb
@@ -6,10 +6,20 @@ describe ArticleJSON::Elements::List do
       content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
     )
   end
+  let(:hash) { params.merge(type: :list, content: [content.to_h]) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :list, content: [content.to_h]) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::List }
+    it 'has the correct values' do
+      expect(subject.content).to all be_a ArticleJSON::Elements::Paragraph
+      expect(subject.list_type).to eq hash[:list_type]
+    end
   end
 end

--- a/spec/article_json/elements/paragraph_spec.rb
+++ b/spec/article_json/elements/paragraph_spec.rb
@@ -2,10 +2,19 @@ describe ArticleJSON::Elements::Paragraph do
   subject(:element) { described_class.new(**params) }
   let(:params) { { content: [content] } }
   let(:content) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:hash) { params.merge(type: :paragraph, content: [content.to_h]) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :paragraph, content: [content.to_h]) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::Paragraph }
+    it 'has the correct values' do
+      expect(subject.content).to all be_a ArticleJSON::Elements::Text
+    end
   end
 end

--- a/spec/article_json/elements/quote_spec.rb
+++ b/spec/article_json/elements/quote_spec.rb
@@ -7,19 +7,28 @@ describe ArticleJSON::Elements::Quote do
       content: [ArticleJSON::Elements::Text.new(content: 'Bar Baz')]
     )
   end
+  let(:hash) do
+    {
+      type: :quote,
+      content: [content.to_h],
+      caption: [caption.to_h],
+      float: :left,
+    }
+  end
 
   describe '#to_h' do
     subject { element.to_h }
-    let(:expected_hash) do
-      {
-        type: :quote,
-        content: [content.to_h],
-        caption: [caption.to_h],
-        float: :left,
-      }
-    end
-
     it { should be_a Hash }
-    it { should eq expected_hash }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::Quote }
+    it 'has the correct values' do
+      expect(subject.content).to all be_a ArticleJSON::Elements::Paragraph
+      expect(subject.caption).to all be_a ArticleJSON::Elements::Text
+      expect(subject.float).to eq hash[:float]
+    end
   end
 end

--- a/spec/article_json/elements/text_box_spec.rb
+++ b/spec/article_json/elements/text_box_spec.rb
@@ -6,10 +6,20 @@ describe ArticleJSON::Elements::TextBox do
       content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
     )
   end
+  let(:hash) { params.merge(type: :text_box, content: [content.to_h]) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :text_box, content: [content.to_h]) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::TextBox }
+    it 'has the correct values' do
+      expect(subject.content).to all be_a ArticleJSON::Elements::Paragraph
+      expect(subject.float).to eq hash[:float]
+    end
   end
 end

--- a/spec/article_json/elements/text_spec.rb
+++ b/spec/article_json/elements/text_spec.rb
@@ -1,10 +1,22 @@
 describe ArticleJSON::Elements::Text do
   subject(:element) { described_class.new(**params) }
   let(:params) { { content: 'Foobar', bold: true, italic: true, href: '/foo' } }
+  let(:hash) { params.merge(type: :text) }
 
   describe '#to_h' do
     subject { element.to_h }
     it { should be_a Hash }
-    it { should eq params.merge(type: :text) }
+    it { should eq hash }
+  end
+
+  describe '.parse_hash' do
+    subject { described_class.parse_hash(hash) }
+    it { should be_a ArticleJSON::Elements::Text }
+    it 'has the correct values' do
+      expect(subject.content).to eq hash[:content]
+      expect(subject.href).to eq hash[:href]
+      expect(subject.bold).to eq hash[:bold]
+      expect(subject.italic).to eq hash[:italic]
+    end
   end
 end


### PR DESCRIPTION
This allows to initialize the intermediate format from hashes, which are obtained by parsing json code.

The added integration test parses the json fixture and "jsonifies" it to make result and source are identical.

This looks quite big, but it a lot of repetition and tests. Sorry :)