### PR TITLE
HTML export for text elements

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -35,3 +35,6 @@ require_relative 'article_json/import/google_doc/html/embedded_youtube_video_par
 require_relative 'article_json/import/google_doc/html/embedded_slideshare_parser'
 require_relative 'article_json/import/google_doc/html/embedded_tweet_parser'
 require_relative 'article_json/import/google_doc/html/parser'
+
+require_relative 'article_json/export/html/elements/base'
+require_relative 'article_json/export/html/elements/text'

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -38,3 +38,4 @@ require_relative 'article_json/import/google_doc/html/parser'
 
 require_relative 'article_json/export/html/elements/base'
 require_relative 'article_json/export/html/elements/text'
+require_relative 'article_json/export/html/elements/heading'

--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -1,0 +1,24 @@
+module ArticleJSON
+  module Export
+    module HTML
+      module Elements
+        class Base
+          # @param [ArticleJSON::Elements::Base] element
+          def initialize(element)
+            @element = element
+          end
+
+          private
+
+          def create_element(tag, *args)
+            Nokogiri::HTML.fragment('').document.create_element(tag.to_s, *args)
+          end
+
+          def create_text_node(text)
+            Nokogiri::HTML.fragment(text).children.first
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/html/elements/heading.rb
+++ b/lib/article_json/export/html/elements/heading.rb
@@ -1,0 +1,19 @@
+module ArticleJSON
+  module Export
+    module HTML
+      module Elements
+        class Heading < Base
+          def build
+            create_element(tag_name, @element.content)
+          end
+
+          private
+
+          def tag_name
+            "h#{@element.level}".to_sym
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/html/elements/text.rb
+++ b/lib/article_json/export/html/elements/text.rb
@@ -1,0 +1,44 @@
+module ArticleJSON
+  module Export
+    module HTML
+      module Elements
+        class Text < Base
+          # @return [Nokogiri::HTML::Node]
+          def build
+            return bold_and_italic_node if @element.bold && @element.italic
+            return bold_node if @element.bold
+            return italic_node if @element.italic
+            content_node
+          end
+
+          private
+
+          # @return [Nokogiri::HTML::Node]
+          def italic_node
+            create_element(:em).tap { |em| em.add_child(content_node) }
+          end
+
+          # @return [Nokogiri::HTML::Node]
+          def bold_node
+            create_element(:strong).tap do |strong|
+              strong.add_child(content_node)
+            end
+          end
+
+          # @return [Nokogiri::HTML::Node]
+          def bold_and_italic_node
+            create_element(:strong).tap do |strong|
+              strong.add_child(italic_node)
+            end
+          end
+
+          # @return [Nokogiri::HTML::Node]
+          def content_node
+            return create_text_node(@element.content) if @element.href.nil?
+            create_element(:a, @element.content, href: @element.href)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/elements/export/html/heading_spec.rb
+++ b/spec/article_json/elements/export/html/heading_spec.rb
@@ -1,0 +1,18 @@
+describe ArticleJSON::Export::HTML::Elements::Heading do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Heading.new(content: 'Foo Bar', level: level)
+  end
+
+  describe '#build' do
+    subject { element.build.to_html }
+
+    (1..6).each do |i|
+      context "when the heading level is #{i}" do
+        let(:level) { i }
+        it { should eq "<h#{level}>Foo Bar</h#{level}>" }
+      end
+    end
+  end
+end

--- a/spec/article_json/elements/export/html/text_spec.rb
+++ b/spec/article_json/elements/export/html/text_spec.rb
@@ -1,0 +1,64 @@
+describe ArticleJSON::Export::HTML::Elements::Text do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Text.new(
+      content: 'Foo Bar',
+      bold: bold,
+      italic: italic,
+      href: href
+    )
+  end
+  let(:bold) { false }
+  let(:italic) { false }
+  let(:href) { nil }
+
+  describe '#build' do
+    subject { element.build.to_html }
+
+    context 'when the source element is plain text' do
+      it { should eq 'Foo Bar' }
+    end
+
+    context 'when the source element is bold text' do
+      let(:bold) { true }
+      it { should eq '<strong>Foo Bar</strong>' }
+    end
+
+    context 'when the source element is italic text' do
+      let(:italic) { true }
+      it { should eq '<em>Foo Bar</em>' }
+    end
+
+    context 'when the source element is italic and bold text' do
+      let(:bold) { true }
+      let(:italic) { true }
+      it { should eq '<strong><em>Foo Bar</em></strong>' }
+    end
+
+    context 'when the source element is a link' do
+      let(:href) { '/foo/bar' }
+      let(:expected_link) { '<a href="/foo/bar">Foo Bar</a>' }
+
+      context 'with plain text' do
+        it { should eq expected_link }
+      end
+
+      context 'with bold text' do
+        let(:bold) { true }
+        it { should eq "<strong>#{expected_link}</strong>" }
+      end
+
+      context 'with italic text' do
+        let(:italic) { true }
+        it { should eq "<em>#{expected_link}</em>" }
+      end
+
+      context 'with italic and bold text' do
+        let(:bold) { true }
+        let(:italic) { true }
+        it { should eq "<strong><em>#{expected_link}</em></strong>" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Text elements are exported to HTML, taking both links and styling into account.