### PR TITLE
Add custom configuration support and set oembed user agent

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -7,7 +7,7 @@ require 'nokogiri'
 require 'css_parser'
 
 require_relative 'article_json/version'
-
+require_relative 'article_json/configuration'
 require_relative 'article_json/utils'
 
 require_relative 'article_json/elements/base'

--- a/lib/article_json/configuration.rb
+++ b/lib/article_json/configuration.rb
@@ -1,0 +1,24 @@
+module ArticleJSON
+  ## Add configuration access and block to main module
+  class << self
+    attr_accessor :configuration
+
+    # @return [ArticleJSON::Configuration]
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
+
+  class Configuration
+    attr_accessor :oembed_user_agent
+
+    def initialize
+      @oembed_user_agent = nil
+    end
+  end
+end
+

--- a/lib/article_json/utils/o_embed_resolver/base.rb
+++ b/lib/article_json/utils/o_embed_resolver/base.rb
@@ -28,7 +28,11 @@ module ArticleJSON
 
         # @return [Hash]
         def http_headers
-          { 'Content-Type' => 'application/json' }
+          headers = { 'Content-Type' => 'application/json' }
+          unless ArticleJSON.configuration.oembed_user_agent.nil?
+            headers['User-Agent'] = ArticleJSON.configuration.oembed_user_agent
+          end
+          headers
         end
 
         class << self

--- a/spec/article_json/configuration_spec.rb
+++ b/spec/article_json/configuration_spec.rb
@@ -1,0 +1,26 @@
+describe ArticleJSON::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe 'configuration block' do
+    it 'should set the configuration values correctly' do
+      expect { ArticleJSON.configure { |c| c.oembed_user_agent = 'foo' } }.to(
+        change { ArticleJSON.configuration.oembed_user_agent }
+          .from(nil)
+          .to('foo')
+      )
+    end
+  end
+
+  describe '#oembed_user_agent' do
+    subject { configuration.oembed_user_agent }
+
+    context 'when not initialized' do
+      it { should be nil }
+    end
+
+    context 'when it has a value' do
+      before { configuration.instance_variable_set(:@oembed_user_agent, 'foo') }
+      it { should eq 'foo' }
+    end
+  end
+end

--- a/spec/article_json/utlis/o_embed_resolver/vimeo_video_spec.rb
+++ b/spec/article_json/utlis/o_embed_resolver/vimeo_video_spec.rb
@@ -22,6 +22,7 @@ describe ArticleJSON::Utils::OEmbedResolver::VimeoVideo do
 
     let(:oembed_response) { File.read('spec/fixtures/vimeo_video_oembed.json') }
     let(:expected_headers) { { 'Content-Type' => 'application/json' } }
+    let(:expected_response) { JSON.parse(oembed_response, symbolize_names: 1) }
 
     before do
       stub_request(:get, expected_oembed_url)
@@ -29,6 +30,14 @@ describe ArticleJSON::Utils::OEmbedResolver::VimeoVideo do
         .to_return(body: oembed_response)
     end
 
-    it { should eq JSON.parse(oembed_response, symbolize_names: true) }
+    context 'with no additional headers' do
+      it { should eq expected_response }
+    end
+
+    context 'with additional headers' do
+      before { ArticleJSON.configure { |c| c.oembed_user_agent = 'foobar' } }
+      let(:expected_headers) { super().merge('User-Agent' => 'foobar') }
+      it { should eq expected_response }
+    end
   end
 end


### PR DESCRIPTION
#### Add top level configuration block
This allows the gem consumer to set configuration values the ruby-way:
```ruby
ArticleJSON.configure do |config|
  config.oembed_user_agent = 'article-json oembed'
end
```

#### Set user agent header for oembed requests
Certain services (like facebook) require a user agent for oembed requests, now we can easily set one via config :tada: