### PR TITLE
Fix flaky configuration test

### DIFF
--- a/spec/article_json/configuration_spec.rb
+++ b/spec/article_json/configuration_spec.rb
@@ -2,6 +2,8 @@ describe ArticleJSON::Configuration do
   subject(:configuration) { described_class.new }
 
   describe 'configuration block' do
+    # make sure we test with a fresh config...
+    before { ArticleJSON.configuration = configuration }
     it 'should set the configuration values correctly' do
       expect { ArticleJSON.configure { |c| c.oembed_user_agent = 'foo' } }.to(
         change { ArticleJSON.configuration.oembed_user_agent }
@@ -19,7 +21,7 @@ describe ArticleJSON::Configuration do
     end
 
     context 'when it has a value' do
-      before { configuration.instance_variable_set(:@oembed_user_agent, 'foo') }
+      before { configuration.oembed_user_agent = 'foo' }
       it { should eq 'foo' }
     end
   end


### PR DESCRIPTION
Is the oembed test (which sets the user agent setting) runs first, the config test would fail. Now we always ensure an empty config.