### PR TITLE
Refactor element constructor pattern

### DIFF
--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -8,13 +8,13 @@ module ArticleJSON
             @element = element
           end
 
-          # Build a HTML node out of the given element
+          # Export a HTML node out of the given element
           # Dynamically looks up the right export-element-class, instantiates it
           # and then calls the #build method.
           # @return [Nokogiri::HTML::Node]
-          def build
-            klass = self.class.element_classes[@element.type]
-            klass.new(@element).build unless klass.nil?
+          def export
+            exporter = self.class == Base ? self.class.build(@element) : self
+            exporter.export unless exporter.nil?
           end
 
           private
@@ -28,7 +28,18 @@ module ArticleJSON
           end
 
           class << self
-            def element_classes
+            # Instantiate the correct sub class for a given element
+            # @param [ArticleJSON::Elements::Base] element
+            # @return [ArticleJSON::Export::HTML::Elements::Base]
+            def build(element)
+              klass = exporter_by_type(element.type)
+              klass.new(element) unless klass.nil?
+            end
+
+            # Look up the correct exporter class based on the element type
+            # @param [Symbol] type
+            # @return [ArticleJSON::Export::HTML::Elements::Base]
+            def exporter_by_type(type)
               {
                 text: Text,
                 paragraph: Paragraph,
@@ -38,7 +49,7 @@ module ArticleJSON
                 text_box: TextBox,
                 quote: Quote,
                 embed: Embed,
-              }
+              }[type.to_sym]
             end
           end
         end

--- a/lib/article_json/export/html/elements/embed.rb
+++ b/lib/article_json/export/html/elements/embed.rb
@@ -5,7 +5,7 @@ module ArticleJSON
         class Embed < Base
           include Shared::Caption
 
-          def build
+          def export
             create_element(:figure).tap do |figure|
               figure.add_child(embed_node)
               figure.add_child(caption_node(:figcaption))

--- a/lib/article_json/export/html/elements/heading.rb
+++ b/lib/article_json/export/html/elements/heading.rb
@@ -3,7 +3,7 @@ module ArticleJSON
     module HTML
       module Elements
         class Heading < Base
-          def build
+          def export
             create_element(tag_name, @element.content)
           end
 

--- a/lib/article_json/export/html/elements/image.rb
+++ b/lib/article_json/export/html/elements/image.rb
@@ -7,7 +7,7 @@ module ArticleJSON
           include Shared::Float
 
           # @return [Nokogiri::HTML::Node]
-          def build
+          def export
             create_element(:figure, node_opts).tap do |figure|
               figure.add_child(image_node)
               figure.add_child(caption_node(:figcaption))

--- a/lib/article_json/export/html/elements/list.rb
+++ b/lib/article_json/export/html/elements/list.rb
@@ -3,11 +3,11 @@ module ArticleJSON
     module HTML
       module Elements
         class List < Base
-          def build
+          def export
             create_element(tag_name).tap do |list|
               @element.content.each do |child_element|
                 item = create_element(:li)
-                item.add_child(Paragraph.new(child_element).build)
+                item.add_child(Paragraph.new(child_element).export)
                 list.add_child(item)
               end
             end

--- a/lib/article_json/export/html/elements/paragraph.rb
+++ b/lib/article_json/export/html/elements/paragraph.rb
@@ -3,10 +3,10 @@ module ArticleJSON
     module HTML
       module Elements
         class Paragraph < Base
-          def build
+          def export
             create_element(:p).tap do |p|
               @element.content.each do |child_element|
-                p.add_child(Text.new(child_element).build)
+                p.add_child(Text.new(child_element).export)
               end
             end
           end

--- a/lib/article_json/export/html/elements/quote.rb
+++ b/lib/article_json/export/html/elements/quote.rb
@@ -6,10 +6,10 @@ module ArticleJSON
           include Shared::Caption
           include Shared::Float
 
-          def build
+          def export
             create_element(:aside, node_opts).tap do |aside|
               @element.content.each do |child_element|
-                aside.add_child(Base.new(child_element).build)
+                aside.add_child(Base.new(child_element).export)
               end
               aside.add_child(caption_node(:small))
             end

--- a/lib/article_json/export/html/elements/shared/caption.rb
+++ b/lib/article_json/export/html/elements/shared/caption.rb
@@ -10,7 +10,7 @@ module ArticleJSON
             def caption_node(tag_name)
               create_element(tag_name).tap do |caption|
                 @element.caption.each do |child_element|
-                  caption.add_child(Text.new(child_element).build)
+                  caption.add_child(Text.new(child_element).export)
                 end
               end
             end

--- a/lib/article_json/export/html/elements/text.rb
+++ b/lib/article_json/export/html/elements/text.rb
@@ -4,7 +4,7 @@ module ArticleJSON
       module Elements
         class Text < Base
           # @return [Nokogiri::HTML::Node]
-          def build
+          def export
             return bold_and_italic_node if @element.bold && @element.italic
             return bold_node if @element.bold
             return italic_node if @element.italic

--- a/lib/article_json/export/html/elements/text_box.rb
+++ b/lib/article_json/export/html/elements/text_box.rb
@@ -5,10 +5,10 @@ module ArticleJSON
         class TextBox < Base
           include Shared::Float
 
-          def build
+          def export
             create_element(:div, node_opts).tap do |div|
               @element.content.each do |child_element|
-                div.add_child(Base.new(child_element).build)
+                div.add_child(Base.new(child_element).export)
               end
             end
           end

--- a/lib/article_json/export/html/exporter.rb
+++ b/lib/article_json/export/html/exporter.rb
@@ -12,7 +12,7 @@ module ArticleJSON
         def html
           doc = Nokogiri::HTML.fragment('')
           @elements.each do |element|
-            doc.add_child(Elements::Base.new(element).build)
+            doc.add_child(Elements::Base.new(element).export)
           end
           doc.to_html(save_with: 0)
         end

--- a/spec/article_json/export/html/elements/base_spec.rb
+++ b/spec/article_json/export/html/elements/base_spec.rb
@@ -1,8 +1,8 @@
 describe ArticleJSON::Export::HTML::Elements::Base do
   subject(:element) { described_class.new(source_element) }
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     let(:sample_text) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
     let(:sample_paragraph) do
@@ -80,12 +80,98 @@ describe ArticleJSON::Export::HTML::Elements::Base do
     end
   end
 
-  describe '#element_classes' do
-    subject { described_class.element_classes }
-    it { should be_a Hash }
-    it('should have Symbol-keys') { expect(subject.keys).to all be_a Symbol }
-    it('should have sub classes as values') do
-      expect(subject.values.map(&:allocate)).to all be_a described_class
+  describe '.build' do
+    subject { described_class.build(element) }
+
+    context 'when the element type is text' do
+      let(:element) { ArticleJSON::Elements::Text.new(content: '') }
+      it { should be_a ArticleJSON::Export::HTML::Elements::Text }
+    end
+
+    context 'when the element type is heading' do
+      let(:element) { ArticleJSON::Elements::Heading.new(content: 1, level: 1) }
+      it { should be_a ArticleJSON::Export::HTML::Elements::Heading }
+    end
+
+    context 'when the element type is paragraph' do
+      let(:element) { ArticleJSON::Elements::Paragraph.new(content: []) }
+      it { should be_a ArticleJSON::Export::HTML::Elements::Paragraph }
+    end
+
+    context 'when the element type is list' do
+      let(:element) { ArticleJSON::Elements::List.new(content: []) }
+      it { should be_a ArticleJSON::Export::HTML::Elements::List }
+    end
+
+    context 'when the element type is image' do
+      let(:element) do
+        ArticleJSON::Elements::Image.new(source_url: '', caption: [])
+      end
+      it { should be_a ArticleJSON::Export::HTML::Elements::Image }
+    end
+
+    context 'when the element type is text_box' do
+      let(:element) { ArticleJSON::Elements::TextBox.new(content: []) }
+      it { should be_a ArticleJSON::Export::HTML::Elements::TextBox }
+    end
+
+    context 'when the element type is quote' do
+      let(:element) do
+        ArticleJSON::Elements::Quote.new(content: [], caption: [])
+      end
+      it { should be_a ArticleJSON::Export::HTML::Elements::Quote }
+    end
+
+    context 'when the element type is embed' do
+      let(:element) do
+        ArticleJSON::Elements::Embed
+          .new(embed_type: '', embed_id: '', caption: [])
+      end
+      it { should be_a ArticleJSON::Export::HTML::Elements::Embed }
+    end
+  end
+
+  describe '.exporter_by_type' do
+    subject { described_class.exporter_by_type(element_type) }
+
+    context 'when the element type is text' do
+      let(:element_type) { :text }
+      it { should be ArticleJSON::Export::HTML::Elements::Text }
+    end
+
+    context 'when the element type is heading' do
+      let(:element_type) { :heading }
+      it { should be ArticleJSON::Export::HTML::Elements::Heading }
+    end
+
+    context 'when the element type is paragraph' do
+      let(:element_type) { :paragraph }
+      it { should be ArticleJSON::Export::HTML::Elements::Paragraph }
+    end
+
+    context 'when the element type is list' do
+      let(:element_type) { :list }
+      it { should be ArticleJSON::Export::HTML::Elements::List }
+    end
+
+    context 'when the element type is image' do
+      let(:element_type) { :image }
+      it { should be ArticleJSON::Export::HTML::Elements::Image }
+    end
+
+    context 'when the element type is text_box' do
+      let(:element_type) { :text_box }
+      it { should be ArticleJSON::Export::HTML::Elements::TextBox }
+    end
+
+    context 'when the element type is quote' do
+      let(:element_type) { :quote }
+      it { should be ArticleJSON::Export::HTML::Elements::Quote }
+    end
+
+    context 'when the element type is embed' do
+      let(:element_type) { :embed }
+      it { should be ArticleJSON::Export::HTML::Elements::Embed }
     end
   end
 end

--- a/spec/article_json/export/html/elements/embed_spec.rb
+++ b/spec/article_json/export/html/elements/embed_spec.rb
@@ -10,8 +10,8 @@ describe ArticleJSON::Export::HTML::Elements::Embed do
     )
   end
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
     let(:expected_html) do
       '<figure><div class="embed">Embedded Object: something-666</div>' \
         '<figcaption>Foo Bar</figcaption></figure>'

--- a/spec/article_json/export/html/elements/heading_spec.rb
+++ b/spec/article_json/export/html/elements/heading_spec.rb
@@ -5,8 +5,8 @@ describe ArticleJSON::Export::HTML::Elements::Heading do
     ArticleJSON::Elements::Heading.new(content: 'Foo Bar', level: level)
   end
 
-  describe '#build' do
-    subject { element.build.to_html }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     (1..6).each do |i|
       context "when the heading level is #{i}" do

--- a/spec/article_json/export/html/elements/image_spec.rb
+++ b/spec/article_json/export/html/elements/image_spec.rb
@@ -11,8 +11,8 @@ describe ArticleJSON::Export::HTML::Elements::Image do
   let(:float) { nil }
   let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     context 'when the image is not floating' do
       let(:expected_html) do

--- a/spec/article_json/export/html/elements/list_spec.rb
+++ b/spec/article_json/export/html/elements/list_spec.rb
@@ -22,8 +22,8 @@ describe ArticleJSON::Export::HTML::Elements::List do
     end
   end
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     context 'when it is an ordered list' do
       let(:list_type) { :ordered }

--- a/spec/article_json/export/html/elements/paragraph_spec.rb
+++ b/spec/article_json/export/html/elements/paragraph_spec.rb
@@ -11,8 +11,8 @@ describe ArticleJSON::Export::HTML::Elements::Paragraph do
     ArticleJSON::Elements::Text.new(content: 'Foo Bar', href: '/foo/bar')
   end
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
     let(:expected_html) do
       '<p><strong>Check this out: </strong><a href="/foo/bar">Foo Bar</a></p>'
     end

--- a/spec/article_json/export/html/elements/quote_spec.rb
+++ b/spec/article_json/export/html/elements/quote_spec.rb
@@ -13,8 +13,8 @@ describe ArticleJSON::Export::HTML::Elements::Quote do
     )
   end
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     context 'when the quote is not floating' do
       let(:float) { nil }

--- a/spec/article_json/export/html/elements/text_box_spec.rb
+++ b/spec/article_json/export/html/elements/text_box_spec.rb
@@ -12,8 +12,8 @@ describe ArticleJSON::Export::HTML::Elements::TextBox do
     )
   end
 
-  describe '#build' do
-    subject { element.build.to_html(save_with: 0) }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     context 'when the box is not floating' do
       let(:float) { nil }

--- a/spec/article_json/export/html/elements/text_spec.rb
+++ b/spec/article_json/export/html/elements/text_spec.rb
@@ -13,8 +13,8 @@ describe ArticleJSON::Export::HTML::Elements::Text do
   let(:italic) { false }
   let(:href) { nil }
 
-  describe '#build' do
-    subject { element.build.to_html }
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
 
     context 'when the source element is plain text' do
       it { should eq 'Foo Bar' }


### PR DESCRIPTION
Slight change to the pattern to dynamically create exporter objects.

This is now aligned with the oembed resolver:
- `Base.build(element)` -> create a exporter object
- `Base.exporter_by_type(type)` -> find exporter class for element
- `Base#export` -> create a exporter object (if necessary) and call `#export` on it
- `*#export` -> export a nokogiri node