### PR TITLE
Add option for custom HTML element exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## ? - WIP
+- Configurable HTML element exporters
 
 ## 0.1.0 - 2017/09/20
 This is the very first release, with the following functionality:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ $ ./bin/article_json_export_google_doc.rb $DOC_ID \
     | ./bin/article_json_export_html.rb
 ```
 
+### Configuration
+There are some configuration options that allow a more tailored usage of the
+`article_json` gem. The following code snippet gives an example for every
+available setting: 
+
+```ruby
+ArticleJSON.configure do |config|
+  # set a custom user agent used for o-embed API calls
+  config.oembed_user_agent = 'devex oembed (+https://www.devex.com/)'
+
+  # Register additional html exporters, just make sure that it complies with the
+  # interface of other element exporter classes (extend Base, implement #export)
+  config.register_html_element_exporter(
+    :advertisement, ArticleJSON::Export::HTML::Elements::Advertisement
+  )
+  # You can also overwrite existing exporters:
+  config.register_html_element_exporter(
+    :image, ArticleJSON::Export::HTML::Elements::ScaledImage
+  )
+end
+``` 
+
 ## Format
 A full example of the format can be found in the test fixtures:
 [Parsed Reference Document](https://github.com/Devex/article_json/blob/master/spec/fixtures/reference_document_parsed.json)

--- a/lib/article_json/configuration.rb
+++ b/lib/article_json/configuration.rb
@@ -15,9 +15,18 @@ module ArticleJSON
 
   class Configuration
     attr_accessor :oembed_user_agent
+    attr_accessor :html_element_exporter
 
     def initialize
       @oembed_user_agent = nil
+      @html_element_exporter = {}
+    end
+
+    # Register a new HTML element exporter or overwrite existing ones.
+    # @param [Symbol] type
+    # @param [Class] klass
+    def register_html_element_exporter(type, klass)
+      @html_element_exporter[type.to_sym] = klass
     end
   end
 end

--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -40,6 +40,17 @@ module ArticleJSON
             # @param [Symbol] type
             # @return [ArticleJSON::Export::HTML::Elements::Base]
             def exporter_by_type(type)
+              key = type.to_sym
+              if ArticleJSON.configuration.html_element_exporter.key?(key)
+                ArticleJSON.configuration.html_element_exporter[key]
+              else
+                default_exporter_mapping[type.to_sym]
+              end
+            end
+
+            private
+
+            def default_exporter_mapping
               {
                 text: Text,
                 paragraph: Paragraph,
@@ -49,7 +60,7 @@ module ArticleJSON
                 text_box: TextBox,
                 quote: Quote,
                 embed: Embed,
-              }[type.to_sym]
+              }
             end
           end
         end

--- a/spec/article_json/configuration_spec.rb
+++ b/spec/article_json/configuration_spec.rb
@@ -1,15 +1,45 @@
 describe ArticleJSON::Configuration do
   subject(:configuration) { described_class.new }
 
+  # make sure we test with a fresh config...
+  before { ArticleJSON.configuration = configuration }
+
+  # make sure we reset to a fresh config after all tests...
+  after(:all) { ArticleJSON.configuration = ArticleJSON::Configuration.new }
+
   describe 'configuration block' do
-    # make sure we test with a fresh config...
-    before { ArticleJSON.configuration = configuration }
     it 'should set the configuration values correctly' do
       expect { ArticleJSON.configure { |c| c.oembed_user_agent = 'foo' } }.to(
         change { ArticleJSON.configuration.oembed_user_agent }
           .from(nil)
           .to('foo')
       )
+    end
+  end
+
+  describe '#register_html_element_exporter' do
+    subject do
+      ArticleJSON.configure do |c|
+        c.register_html_element_exporter(:foo, Object)
+      end
+    end
+
+    context 'when there is no exporter registered' do
+      it 'registers an additional exporter' do
+        expect { subject }.to(
+          change { ArticleJSON.configuration.html_element_exporter }
+            .from({})
+            .to({ foo: Object })
+        )
+      end
+    end
+
+    context 'when there is already an exporter registered' do
+      before { configuration.html_element_exporter = { foo: Object } }
+      it 'registers an additional exporter' do
+        expect { subject }
+          .to_not change { ArticleJSON.configuration.html_element_exporter }
+      end
     end
   end
 
@@ -23,6 +53,19 @@ describe ArticleJSON::Configuration do
     context 'when it has a value' do
       before { configuration.oembed_user_agent = 'foo' }
       it { should eq 'foo' }
+    end
+  end
+
+  describe '#html_element_exporter' do
+    subject { configuration.html_element_exporter }
+
+    context 'when not initialized' do
+      it { should eq({}) }
+    end
+
+    context 'when it has a value' do
+      before { configuration.html_element_exporter = { foo: 'bar' } }
+      it { should eq({ foo: 'bar' }) }
     end
   end
 end

--- a/spec/article_json/export/html/elements/base_spec.rb
+++ b/spec/article_json/export/html/elements/base_spec.rb
@@ -173,5 +173,15 @@ describe ArticleJSON::Export::HTML::Elements::Base do
       let(:element_type) { :embed }
       it { should be ArticleJSON::Export::HTML::Elements::Embed }
     end
+
+    context 'when the element was additionally registered' do
+      before do
+        ArticleJSON.configure do |c|
+          c.register_html_element_exporter(:foo, Object)
+        end
+      end
+      let(:element_type) { :foo }
+      it { should be Object }
+    end
   end
 end


### PR DESCRIPTION
When integrating the gem there is oftentimes the need for a more customized behavior, like additional CSS classes or image scaling.

This simple option setting allows for completely new elements that can be injected before export (like advertisements) or overwriting existing ones (like scaled images).

Example from the README:
```ruby
ArticleJSON.configure do |config|
  # set a custom user agent used for o-embed API calls
  config.oembed_user_agent = 'devex oembed (+https://www.devex.com/)'

  # Register additional html exporters, just make sure that it complies with the
  # interface of other element exporter classes (extend Base, implement #export)
  config.register_html_element_exporter(
    :advertisement, ArticleJSON::Export::HTML::Elements::Advertisement
  )
  # You can also overwrite existing exporters:
  config.register_html_element_exporter(
    :image, ArticleJSON::Export::HTML::Elements::ScaledImage
  )
end
``` 