### PR TITLE
Add amp elements base and text

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -52,4 +52,7 @@ require_relative 'article_json/export/html/elements/quote'
 require_relative 'article_json/export/html/elements/embed'
 require_relative 'article_json/export/html/exporter'
 
+require_relative 'article_json/export/amp/elements/base'
+require_relative 'article_json/export/amp/elements/text'
+
 require_relative 'article_json/article'

--- a/lib/article_json/export/amp/elements/base.rb
+++ b/lib/article_json/export/amp/elements/base.rb
@@ -1,0 +1,52 @@
+module ArticleJSON
+  module Export
+    module AMP
+      module Elements
+        class Base
+          # @param [ArticleJSON::Elements::Base] element
+          def initialize(element)
+            @element = element
+          end
+
+          # Export a HTML node out of the given element
+          # Dynamically looks up the right export-element-class, instantiates it
+          # and then calls the #build method.
+          # @return [Nokogiri::HTML::Node]
+          def export
+            exporter = self.class == Base ? self.class.build(@element) : self
+            exporter.export unless exporter.nil?
+          end
+
+          private
+
+          def create_element(tag, *args)
+            Nokogiri::HTML.fragment('').document.create_element(tag.to_s, *args)
+          end
+
+          def create_text_node(text)
+            Nokogiri::HTML.fragment(text).children.first
+          end
+
+          class << self
+            # Instantiate the correct sub class for a given element
+            # @param [ArticleJSON::Elements::Base] element
+            # @return [ArticleJSON::Export::HTML::Elements::Base]
+            def build(element)
+              klass = exporter_by_type(element.type)
+              klass.new(element) unless klass.nil?
+            end
+
+            # Look up the correct exporter class based on the element type
+            # @param [Symbol] type
+            # @return [ArticleJSON::Export::HTML::Elements::Base]
+            def exporter_by_type(type)
+              {
+                text: Text,
+              }[type.to_sym]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/amp/elements/text.rb
+++ b/lib/article_json/export/amp/elements/text.rb
@@ -1,0 +1,44 @@
+module ArticleJSON
+  module Export
+    module AMP
+      module Elements
+        class Text < Base
+          # @return [Nokogiri::HTML::Node]
+          def export
+            return bold_and_italic_node if @element.bold && @element.italic
+            return bold_node if @element.bold
+            return italic_node if @element.italic
+            content_node
+          end
+
+          private
+
+          # @return [Nokogiri::HTML::Node]
+          def italic_node
+            create_element(:em).tap { |em| em.add_child(content_node) }
+          end
+
+          # @return [Nokogiri::HTML::Node]
+          def bold_node
+            create_element(:strong).tap do |strong|
+              strong.add_child(content_node)
+            end
+          end
+
+          # @return [Nokogiri::HTML::Node]
+          def bold_and_italic_node
+            create_element(:strong).tap do |strong|
+              strong.add_child(italic_node)
+            end
+          end
+
+          # @return [Nokogiri::HTML::Node]
+          def content_node
+            return create_text_node(@element.content) if @element.href.nil?
+            create_element(:a, @element.content, href: @element.href)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/export/amp/elements/base_spec.rb
+++ b/spec/article_json/export/amp/elements/base_spec.rb
@@ -1,0 +1,35 @@
+describe ArticleJSON::Export::AMP::Elements::Base do
+  subject(:element) { described_class.new(source_element) }
+
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
+
+    let(:sample_text) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+    let(:sample_paragraph) do
+      ArticleJSON::Elements::Paragraph.new(content: [sample_text])
+    end
+
+    context 'when the source element is a text' do
+      let(:source_element) { sample_text }
+      it { should eq 'Foo Bar' }
+    end
+  end
+
+  describe '.build' do
+    subject { described_class.build(element) }
+
+    context 'when the element type is text' do
+      let(:element) { ArticleJSON::Elements::Text.new(content: '') }
+      it { should be_a ArticleJSON::Export::AMP::Elements::Text }
+    end
+  end
+
+  describe '.exporter_by_type' do
+    subject { described_class.exporter_by_type(element_type) }
+
+    context 'when the element type is text' do
+      let(:element_type) { :text }
+      it { should be ArticleJSON::Export::AMP::Elements::Text }
+    end
+  end
+end

--- a/spec/article_json/export/amp/elements/base_spec.rb
+++ b/spec/article_json/export/amp/elements/base_spec.rb
@@ -5,9 +5,6 @@ describe ArticleJSON::Export::AMP::Elements::Base do
     subject { element.export.to_html(save_with: 0) }
 
     let(:sample_text) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
-    let(:sample_paragraph) do
-      ArticleJSON::Elements::Paragraph.new(content: [sample_text])
-    end
 
     context 'when the source element is a text' do
       let(:source_element) { sample_text }

--- a/spec/article_json/export/amp/elements/text_spec.rb
+++ b/spec/article_json/export/amp/elements/text_spec.rb
@@ -1,0 +1,64 @@
+describe ArticleJSON::Export::AMP::Elements::Text do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Text.new(
+      content: 'Foo Bar',
+      bold: bold,
+      italic: italic,
+      href: href
+    )
+  end
+  let(:bold) { false }
+  let(:italic) { false }
+  let(:href) { nil }
+
+  describe '#export' do
+    subject { element.export.to_html(save_with: 0) }
+
+    context 'when the source element is plain text' do
+      it { should eq 'Foo Bar' }
+    end
+
+    context 'when the source element is bold text' do
+      let(:bold) { true }
+      it { should eq '<strong>Foo Bar</strong>' }
+    end
+
+    context 'when the source element is italic text' do
+      let(:italic) { true }
+      it { should eq '<em>Foo Bar</em>' }
+    end
+
+    context 'when the source element is italic and bold text' do
+      let(:bold) { true }
+      let(:italic) { true }
+      it { should eq '<strong><em>Foo Bar</em></strong>' }
+    end
+
+    context 'when the source element is a link' do
+      let(:href) { '/foo/bar' }
+      let(:expected_link) { '<a href="/foo/bar">Foo Bar</a>' }
+
+      context 'with plain text' do
+        it { should eq expected_link }
+      end
+
+      context 'with bold text' do
+        let(:bold) { true }
+        it { should eq "<strong>#{expected_link}</strong>" }
+      end
+
+      context 'with italic text' do
+        let(:italic) { true }
+        it { should eq "<em>#{expected_link}</em>" }
+      end
+
+      context 'with italic and bold text' do
+        let(:bold) { true }
+        let(:italic) { true }
+        it { should eq "<strong><em>#{expected_link}</em></strong>" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
As a first step into adding amp export support, we add element base and element
text.