### PR TITLE
Make Google Doc Parser more fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Configurable HTML element exporters
 - Resolve oembed elements in HTML export
 - Export quotes as `<div>` instead of `<aside>`
+- Make Google Parser more fault tolerant
 
 ## 0.1.0 - 2017/09/20
 This is the very first release, with the following functionality:

--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -72,7 +72,7 @@ module ArticleJSON
             ImageParser
               .new(
                 node: @current_node.node,
-                caption_node: @body_enumerator.next,
+                caption_node: next_node,
                 css_analyzer: @css_analyzer
               )
               .element
@@ -96,7 +96,7 @@ module ArticleJSON
           def parse_embed
             EmbeddedParser.build(
               node: @current_node.node,
-              caption_node: @body_enumerator.next,
+              caption_node: next_node,
               css_analyzer: @css_analyzer
             )
           end
@@ -106,9 +106,16 @@ module ArticleJSON
           def nodes_until_hr
             nodes = []
             until NodeAnalyzer.new(@body_enumerator.peek).hr?
+              break unless body_has_more_nodes?
               nodes << @body_enumerator.next
             end
             nodes
+          end
+
+          # Return the next node if available, and advance the enumerator
+          # @return [Nokogiri::HTML::Node]
+          def next_node
+            body_has_more_nodes? ? @body_enumerator.next : nil
           end
 
           # @return [Boolean]

--- a/lib/article_json/import/google_doc/html/shared/caption.rb
+++ b/lib/article_json/import/google_doc/html/shared/caption.rb
@@ -7,10 +7,17 @@ module ArticleJSON
             # Parse the caption node
             # @return [Array[ArticleJSON::Elements::Text]]
             def caption
+              return empty_caption if @caption_node.nil?
               ArticleJSON::Import::GoogleDoc::HTML::TextParser.extract(
                 node: @caption_node,
                 css_analyzer: @css_analyzer
               )
+            end
+
+            private
+
+            def empty_caption
+              [ArticleJSON::Elements::Text.new(content: '&nbsp;')]
             end
           end
         end

--- a/spec/article_json/import/google_doc/html/embedded_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/embedded_parser_spec.rb
@@ -47,10 +47,18 @@ describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedParser do
     it 'returns a list of text elements' do
       expect(subject).to be_an Array
       expect(subject.size).to eq 1
-
       expect(subject).to all be_a ArticleJSON::Elements::Text
-
       expect(subject.first.content).to eq 'Caption'
+    end
+
+    context 'when the caption nil' do
+      let(:caption_node) { nil }
+      it 'returns a list with one empty text element' do
+        expect(subject).to be_an Array
+        expect(subject.size).to eq 1
+        expect(subject).to all be_a ArticleJSON::Elements::Text
+        expect(subject.first.content).to eq '&nbsp;'
+      end
     end
   end
 

--- a/spec/article_json/import/google_doc/html/image_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/image_parser_spec.rb
@@ -144,10 +144,18 @@ describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
     it 'returns a list of text elements' do
       expect(subject).to be_an Array
       expect(subject.size).to eq 1
-
       expect(subject).to all be_a ArticleJSON::Elements::Text
-
       expect(subject.first.content).to eq 'foo'
+    end
+
+    context 'when the caption nil' do
+      let(:caption_node) { nil }
+      it 'returns a list with one empty text element' do
+        expect(subject).to be_an Array
+        expect(subject.size).to eq 1
+        expect(subject).to all be_a ArticleJSON::Elements::Text
+        expect(subject.first.content).to eq '&nbsp;'
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes the document isn't perfectly formatted, for example a missing caption at the end of a document or blocks that are never closed by a horizontal line. These things still will look ugly, but at least won't break.