### PR TITLE
Fix `#nodes_until_hr`

### DIFF
--- a/lib/article_json/import/google_doc/html/parser.rb
+++ b/lib/article_json/import/google_doc/html/parser.rb
@@ -105,8 +105,8 @@ module ArticleJSON
           # @return [Array[Nokogiri::HTML::Node]]
           def nodes_until_hr
             nodes = []
-            until NodeAnalyzer.new(@body_enumerator.peek).hr?
-              break unless body_has_more_nodes?
+            until !body_has_more_nodes? ||
+                NodeAnalyzer.new(@body_enumerator.peek).hr?
               nodes << @body_enumerator.next
             end
             nodes

--- a/spec/article_json/import/google_doc/html/parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/parser_spec.rb
@@ -12,5 +12,42 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
     end
 
     it { should eq minified_json }
+
+    context 'when a text box is not closed' do
+      let(:html) { File.read('spec/fixtures/google_doc_unclosed_textbox.html') }
+      let(:json) do
+        <<-json
+          {
+            "article_json_version": "0.1.0",
+            "content": [
+              {
+                "type": "text_box",
+                "float": "left",
+                "content": [
+                  {
+                    "type": "heading",
+                    "level": 2,
+                    "content": "Text Box without end!"
+                  },
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "content": "Lorem ipsum",
+                        "bold": false,
+                        "italic": false,
+                        "href": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        json
+      end
+      it { should eq minified_json }
+    end
   end
 end

--- a/spec/fixtures/google_doc_unclosed_textbox.html
+++ b/spec/fixtures/google_doc_unclosed_textbox.html
@@ -1,0 +1,1 @@
+<html><head><meta content="text/html; charset=UTF-8" http-equiv="content-type"><style type="text/css"></style></head><body class="c19"><p class="c3"><span class="c4">Textbox:</span></p><h2 class="c27" id="h.ae32nwdccyi5"><span class="c9">Text Box without end!</span></h2><p class="c17"><span class="c1"></span></p><p class="c3"><span class="c8">Lorem ipsum</span></p></body></html>


### PR DESCRIPTION
Check if there are more nodes before calling `peek`, which otherwise throws a `StopIteration` error.

Sometimes the document isn't perfectly formatted, in this case a block that is never closed by a horizontal line.