### PR TITLE
Refactor AMP library resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Export quotes as `<div>` instead of `<aside>`
 - Make Google Parser more fault tolerant
 - Support Vimeo videos with old flash player URLs
+- Export AMP
+- Return required libraries for AMP rendering
 
 ## 0.1.0 - 2017/09/20
 This is the very first release, with the following functionality:

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -1,7 +1,6 @@
 require 'uri'
 require 'cgi'
 require 'json'
-require 'set'
 require 'net/http'
 
 require 'nokogiri'
@@ -64,6 +63,7 @@ require_relative 'article_json/export/amp/elements/quote'
 require_relative 'article_json/export/amp/elements/text_box'
 require_relative 'article_json/export/amp/elements/image'
 require_relative 'article_json/export/amp/elements/embed'
+require_relative 'article_json/export/amp/custom_element_library_resolver'
 require_relative 'article_json/export/amp/exporter'
 
 require_relative 'article_json/article'

--- a/lib/article_json/export/amp/custom_element_library_resolver.rb
+++ b/lib/article_json/export/amp/custom_element_library_resolver.rb
@@ -1,0 +1,55 @@
+module ArticleJSON
+  module Export
+    module AMP
+      # AMP uses custom HTML tags for elements like iframes or embedded youtube
+      # videos. These elements each require a javascript to be loaded to be
+      # properly rendered by the browser. This class resolves the custom tags to
+      # a list of javascript libraries which then can be included on the page.
+      class CustomElementLibraryResolver
+        # @param [Array[Symbol]] custom_element_tags
+        def initialize(custom_element_tags)
+          @custom_element_tags = custom_element_tags
+        end
+
+        # List of all custom tags with their library source URI
+        # @return [Hash[Symbol => String]]
+        def sources
+          @custom_element_tags.each_with_object({}) do |custom_element, mapping|
+            src = custom_element_script_mapping(custom_element)
+            mapping[custom_element] = src if src
+          end
+        end
+
+        # Return all custom library script tags required for the given custom
+        # element tags
+        # @return [Array[String]]
+        def script_tags
+          sources.map do |custom_element_tag, src|
+            <<-HTML.gsub(/\s+/, ' ').strip
+                <script async 
+                        custom-element="#{custom_element_tag}" 
+                        src="#{src}"></script>
+            HTML
+          end
+        end
+
+        private
+
+        # Given a custom_element identifier, get the script script source
+        # @param [Symbol] custom_element_tag
+        # @return [String]
+        def custom_element_script_mapping(custom_element_tag)
+          {
+            'amp-iframe': 'https://cdn.ampproject.org/v0/amp-iframe-0.1.js',
+            'amp-twitter': 'https://cdn.ampproject.org/v0/amp-twitter-0.1.js',
+            'amp-youtube': 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js',
+            'amp-vimeo': 'https://cdn.ampproject.org/v0/amp-vimeo-0.1.js',
+            'amp-facebook':
+              'https://cdn.ampproject.org/v0/amp-facebook-0.1.js',
+          }[custom_element_tag]
+        end
+      end
+    end
+  end
+end
+

--- a/lib/article_json/export/amp/elements/base.rb
+++ b/lib/article_json/export/amp/elements/base.rb
@@ -17,7 +17,11 @@ module ArticleJSON
             exporter.export unless exporter.nil?
           end
 
-          def amp_library; end
+          # List of custom element tags used by this element
+          # @return [Array[Symbol]]
+          def custom_element_tags
+            []
+          end
 
           private
 

--- a/lib/article_json/export/amp/elements/embed.rb
+++ b/lib/article_json/export/amp/elements/embed.rb
@@ -12,10 +12,18 @@ module ArticleJSON
             end
           end
 
-          def amp_library
-            return @amp_library if defined? @amp_library
-            type_specific_node # the execution will determine needed amp library
-            @amp_library
+          # Returns the custom element tags required for this embedded element
+          #
+          # @return [Array[Symbol]]
+          def custom_element_tags
+            case @element.embed_type.to_sym
+            when :youtube_video then %i(amp-youtube)
+            when :vimeo_video then %i(amp-vimeo)
+            when :facebook_video then %i(amp-facebook)
+            when :tweet then %i(amp-twitter)
+            when :slideshare then %i(amp-iframe)
+            else []
+            end
           end
 
           private
@@ -41,52 +49,28 @@ module ArticleJSON
             end
           end
 
-          def youtube_library
-            '<script async custom-element="amp-youtube" ' \
-            'src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>'
-          end
-
           def youtube_node
-            @amp_library = youtube_library
             create_element('amp-youtube',
                            'data-videoid' => @element.embed_id,
                            width: default_width,
                            height: default_height)
           end
 
-          def vimeo_library
-            '<script async custom-element="amp-vimeo"' \
-            'src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>'
-          end
-
           def vimeo_node
-            @amp_library = vimeo_library
             create_element('amp-vimeo',
                            'data-videoid' => @element.embed_id,
                            width: default_width,
                            height: default_height)
           end
 
-          def tweet_library
-            '<script async custom-element="amp-twitter" ' \
-            'src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>'
-          end
-
           def tweet_node
-            @amp_library = tweet_library
             create_element('amp-twitter',
                            'data-tweetid' => @element.embed_id,
                            width: default_width,
                            height: default_height)
           end
 
-          def facebook_library
-            '<script async custom-element="amp-facebook" ' \
-            'src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>'
-          end
-
           def facebook_node
-            @amp_library = facebook_library
             url = "#{@element.oembed_data[:author_url]}videos/#{@element.embed_id}"
             create_element('amp-facebook',
                            'data-embedded-as' => 'video',
@@ -95,13 +79,7 @@ module ArticleJSON
                            height: default_height)
           end
 
-          def iframe_library
-            '<script async custom-element="amp-iframe"' \
-            'src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>'
-          end
-
           def slideshare_node
-            @amp_library = iframe_library
             node = Nokogiri::HTML(@element.oembed_data[:html]).xpath('//iframe')
             create_element('amp-iframe',
                            src: node.attribute('src').value,

--- a/spec/article_json/export/amp/custom_element_library_resolver_spec.rb
+++ b/spec/article_json/export/amp/custom_element_library_resolver_spec.rb
@@ -1,0 +1,89 @@
+describe ArticleJSON::Export::AMP::CustomElementLibraryResolver do
+  subject(:exporter) { described_class.new(tags) }
+  let(:tags) { %i(amp-iframe amp-youtube) }
+
+  describe '#sources' do
+    subject { exporter.sources }
+
+    context 'when initialized with an empty array' do
+      let(:tags) { [] }
+      it { should eq Hash.new }
+    end
+
+    context 'when initialized with single element' do
+      let(:tags) { %i(amp-vimeo) }
+
+      it 'should return the right script source' do
+        expect(subject)
+          .to eq 'amp-vimeo': 'https://cdn.ampproject.org/v0/amp-vimeo-0.1.js'
+      end
+    end
+
+    context 'when initialized with multiple elements' do
+      let(:tags) do
+        %i(
+           amp-iframe
+           amp-twitter
+           amp-youtube
+           amp-vimeo
+           amp-facebook
+          )
+      end
+
+      it 'should return the right script tag' do
+        expect(subject).to(
+          eq 'amp-iframe': 'https://cdn.ampproject.org/v0/amp-iframe-0.1.js',
+             'amp-twitter': 'https://cdn.ampproject.org/v0/amp-twitter-0.1.js',
+             'amp-youtube': 'https://cdn.ampproject.org/v0/amp-youtube-0.1.js',
+             'amp-vimeo': 'https://cdn.ampproject.org/v0/amp-vimeo-0.1.js',
+             'amp-facebook': 'https://cdn.ampproject.org/v0/amp-facebook-0.1.js'
+        )
+      end
+    end
+  end
+
+  describe '#script_tags' do
+    subject { exporter.script_tags }
+
+    context 'when initialized with an empty array' do
+      let(:tags) { [] }
+
+      it { should eq [] }
+    end
+
+    context 'when initialized with single element' do
+      let(:tags) { %i(amp-facebook) }
+
+      it 'should return the right script tag' do
+        expect(subject).to be_an Array
+        expect(subject.size).to eq 1
+        expect(subject.first).to include 'amp-facebook'
+        expect(subject).to(
+          eq ['<script async custom-element="amp-facebook" '\
+                'src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js">'\
+                '</script>']
+        )
+      end
+    end
+
+    context 'when initialized with multiple elements' do
+      let(:tags) { %i(amp-facebook amp-iframe) }
+
+      it 'should return all the right script tags' do
+        expect(subject).to be_an Array
+        expect(subject).to(
+          match_array(
+            [
+              '<script async custom-element="amp-facebook" '\
+                'src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js">'\
+                '</script>',
+              '<script async custom-element="amp-iframe" '\
+                'src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js">'\
+                '</script>',
+            ]
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/article_json/export/amp/elements/base_spec.rb
+++ b/spec/article_json/export/amp/elements/base_spec.rb
@@ -1,5 +1,6 @@
 describe ArticleJSON::Export::AMP::Elements::Base do
   subject(:element) { described_class.new(source_element) }
+  let(:source_element) { ArticleJSON::Elements::Text.new(content: 'Test') }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -10,6 +11,11 @@ describe ArticleJSON::Export::AMP::Elements::Base do
       let(:source_element) { sample_text }
       it { should eq 'Foo Bar' }
     end
+  end
+
+  describe '#custom_element_tags' do
+    subject { element.custom_element_tags }
+    it { should eq [] }
   end
 
   describe '.build' do

--- a/spec/article_json/export/amp/elements/embed_spec.rb
+++ b/spec/article_json/export/amp/elements/embed_spec.rb
@@ -1,18 +1,20 @@
 describe ArticleJSON::Export::AMP::Elements::Embed do
   subject(:element) { described_class.new(source_element) }
+  let(:source_element_embed_type) { :youtube_video }
+  let(:source_element) do
+    ArticleJSON::Elements::Embed.new(
+      embed_type: source_element_embed_type,
+      embed_id: 666,
+      caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
+      tags: %w(test)
+    )
+  end
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
 
     context 'with a youtube video' do
-      let(:source_element) do
-        ArticleJSON::Elements::Embed.new(
-          embed_type: :youtube_video,
-          embed_id: 666,
-          caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
-          tags: %w(test)
-        )
-      end
+      let(:source_element_embed_type) { :youtube_video }
       let(:expected_html) do
         '<figure><div class="embed">' \
         '<amp-youtube data-videoid="666" width="560" height="315">' \
@@ -24,14 +26,7 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
     end
 
     context 'with a vimeo video' do
-      let(:source_element) do
-        ArticleJSON::Elements::Embed.new(
-          embed_type: :vimeo_video,
-          embed_id: 666,
-          caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
-          tags: %w(test)
-        )
-      end
+      let(:source_element_embed_type) { :vimeo_video }
       let(:expected_html) do
         '<figure><div class="embed">' \
         '<amp-vimeo data-videoid="666" width="560" height="315">' \
@@ -44,14 +39,7 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
 
     context 'with a facebook video' do
       let(:url) { 'facebook.com/facebook/videos/666' }
-      let(:source_element) do
-        ArticleJSON::Elements::Embed.new(
-          embed_type: :facebook_video,
-          embed_id: 666,
-          caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
-          tags: %w(test)
-        )
-      end
+      let(:source_element_embed_type) { :facebook_video }
       let(:expected_html) do
         '<figure><div class="embed">' \
         '<amp-facebook ' \
@@ -76,14 +64,7 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
     end
 
     context 'with a tweet' do
-      let(:source_element) do
-        ArticleJSON::Elements::Embed.new(
-          embed_type: :tweet,
-          embed_id: 666,
-          caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
-          tags: %w(test)
-        )
-      end
+      let(:source_element_embed_type) { :tweet }
       let(:expected_html) do
         '<figure><div class="embed">' \
         '<amp-twitter data-tweetid="666" width="560" height="315">' \
@@ -95,14 +76,7 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
     end
 
     context 'with a slideshare presentation' do
-      let(:source_element) do
-        ArticleJSON::Elements::Embed.new(
-          embed_type: :slideshare,
-          embed_id: 666,
-          caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
-          tags: %w(test)
-        )
-      end
+      let(:source_element_embed_type) { :slideshare }
       let(:expected_html) do
         '<figure><div class="embed">' \
         '<amp-iframe ' \
@@ -122,6 +96,35 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
         allow(source_element).to receive(:oembed_data).and_return(oembed_data)
       end
       it { should eq expected_html }
+    end
+  end
+
+  describe '#custom_element_tags' do
+    subject { element.custom_element_tags }
+
+    context 'with a youtube video' do
+      let(:source_element_embed_type) { :youtube_video }
+      it { should eq [:'amp-youtube'] }
+    end
+
+    context 'with a vimeo video' do
+      let(:source_element_embed_type) { :vimeo_video }
+      it { should eq [:'amp-vimeo'] }
+    end
+
+    context 'with a facebook video' do
+      let(:source_element_embed_type) { :facebook_video }
+      it { should eq [:'amp-facebook'] }
+    end
+
+    context 'with a tweet' do
+      let(:source_element_embed_type) { :tweet }
+      it { should eq [:'amp-twitter'] }
+    end
+
+    context 'with a slideshare presentation' do
+      let(:source_element_embed_type) { :slideshare }
+      it { should eq [:'amp-iframe'] }
     end
   end
 end

--- a/spec/article_json/export/amp/exporter_spec.rb
+++ b/spec/article_json/export/amp/exporter_spec.rb
@@ -1,36 +1,44 @@
 describe ArticleJSON::Export::AMP::Exporter do
   subject(:exporter) { described_class.new(elements) }
+  let(:json) { File.read('spec/fixtures/reference_document_parsed.json') }
+  let(:elements) { ArticleJSON::Article.from_json(json).elements }
 
   describe 'reference document test' do
     subject { exporter.html }
     let(:html) { File.read('spec/fixtures/reference_document_exported.amp.html') }
-    let(:json) { File.read('spec/fixtures/reference_document_parsed.json') }
-    let(:elements) { ArticleJSON::Article.from_json(json).elements }
     before { stub_oembed_requests }
     it { should eq html.strip }
   end
 
-  describe 'amp_libraries' do
+  describe '.custom_element_tags' do
+    subject { exporter.custom_element_tags }
+
+    it 'should return the right tags' do
+      expect(subject).to contain_exactly :'amp-vimeo',
+                                         :'amp-youtube',
+                                         :'amp-facebook',
+                                         :'amp-iframe',
+                                         :'amp-twitter'
+    end
+  end
+
+  describe '.amp_libraries' do
     subject { exporter.amp_libraries }
 
-    let(:json) { File.read('spec/fixtures/reference_document_parsed.json') }
-    let(:elements) { ArticleJSON::Article.from_json(json).elements }
     let(:expected_result) do
       [
-        '<script async custom-element="amp-vimeo"' \
+        '<script async custom-element="amp-vimeo" ' \
         'src="https://cdn.ampproject.org/v0/amp-vimeo-0.1.js"></script>',
         '<script async custom-element="amp-youtube" ' \
         'src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>',
         '<script async custom-element="amp-facebook" ' \
         'src="https://cdn.ampproject.org/v0/amp-facebook-0.1.js"></script>',
-        '<script async custom-element="amp-iframe"' \
+        '<script async custom-element="amp-iframe" ' \
         'src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>',
         '<script async custom-element="amp-twitter" ' \
         'src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>'
       ]
     end
-
-    before { stub_oembed_requests }
 
     it { should match_array expected_result }
   end


### PR DESCRIPTION
AMP uses custom HTML tags for elements like iframes or embedded youtube videos. These elements each require a javascript to be loaded to be properly rendered by the browser. 

The new class `ArticleJSON::Export::AMP::CustomElementLibraryResolver` resolves the custom tags to a list of javascript libraries which then can be included on the page.

By adding `ArticleJSON::Export::AMP::Exporter#custom_element_tags` the user can now get a list of all used libraries (e.g. to check if one should manually include an additional `iframe` library for an element used outside of the article).

By refactoring the logic like this, we now also no longer need to parse the AMP element before being able to get a list of all its required custom elements.

The specs for `ArticleJSON::Export::AMP::Exporter.amp_libraries` still pass (only some spacing had to be fixed). Therefore, the (tested) API of the class remains the same.

`ArticleJSON::Export::AMP::Elements::Base.amp_library` (was untested) has been removed and replaced with `.custom_element_tags` which now returns a list of all custom tags used by the element.