### PR TITLE
Support custom AMP exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## ? - WIP
-- Configurable HTML element exporters
+- Configurable HTML and AMP element exporters
 - Resolve oembed elements in HTML export
 - Export quotes as `<div>` instead of `<aside>`
 - Make Google Parser more fault tolerant

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ ArticleJSON.configure do |config|
     advertisement: ArticleJSON::Export::HTML::Elements::Advertisement,
     image: ArticleJSON::Export::HTML::Elements::ScaledImage
   )
+  
+  # It works the same way for custom AMP exporters:
+  config.register_element_exporters_for(
+    :amp,
+    image: ArticleJSON::Export::AMP::Elements::ScaledImage
+  ) 
 end
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,22 @@ ArticleJSON.configure do |config|
 
   # Register additional html exporters, just make sure that it complies with the
   # interface of other element exporter classes (extend Base, implement #export)
-  config.register_html_element_exporter(
-    :advertisement, ArticleJSON::Export::HTML::Elements::Advertisement
+  config.register_element_exporters_for(
+    :html,
+    advertisement: ArticleJSON::Export::HTML::Elements::Advertisement
   )
+  
   # You can also overwrite existing exporters:
-  config.register_html_element_exporter(
-    :image, ArticleJSON::Export::HTML::Elements::ScaledImage
+  config.register_element_exporters_for(
+    :html,
+    image: ArticleJSON::Export::HTML::Elements::ScaledImage
+  )
+  
+  # And you can define multiple custom exporters:
+  config.register_element_exporters_for(
+    :html,
+    advertisement: ArticleJSON::Export::HTML::Elements::Advertisement,
+    image: ArticleJSON::Export::HTML::Elements::ScaledImage
   )
 end
 ``` 

--- a/lib/article_json/configuration.rb
+++ b/lib/article_json/configuration.rb
@@ -15,18 +15,65 @@ module ArticleJSON
 
   class Configuration
     attr_accessor :oembed_user_agent
-    attr_accessor :html_element_exporter
 
     def initialize
       @oembed_user_agent = nil
-      @html_element_exporter = {}
+      @custom_element_exporters = {}
     end
 
     # Register a new HTML element exporter or overwrite existing ones.
     # @param [Symbol] type
     # @param [Class] klass
+    # @deprecated Use `#register_element_exporters_for(:html, ...)` instead
     def register_html_element_exporter(type, klass)
-      @html_element_exporter[type.to_sym] = klass
+      register_element_exporters_for(:html, type => klass)
+    end
+
+    # Return custom HTML exporters
+    # @return [Hash[Symbol => Class]]
+    # @deprecated use `#exporter_for` instead
+    def html_element_exporter
+      @custom_element_exporters[:html] || {}
+    end
+
+    # Set custom HTML exporters
+    # @param [Hash[Symbol => Class]] value
+    # @deprecated use `#register_element_exporters_for(:html, ...)` instead
+    def html_element_exporter=(value)
+      @custom_element_exporters[:html] = value
+    end
+
+    # Register new element exporters or overwrite existing ones for a given
+    # exporter type.
+    # Usage example:
+    #  register_element_exporters_for(:html,
+    #                                 image: MyImageExporter,
+    #                                 advertisement: MyAdExporter)
+    # @param [Symbol] exporter
+    # @param [Hash[Symbol => Class]] type_class_mapping
+    def register_element_exporters_for(exporter, type_class_mapping)
+      unless %i(html).include?(exporter)
+        raise ArgumentError, '`exporter` only supports `:html` '\
+                             "but is `#{exporter.inspect}`"
+      end
+      if !type_class_mapping.is_a?(Hash) ||
+          type_class_mapping.keys.any? { |key| !key.is_a? Symbol } ||
+          type_class_mapping.values.any? { |value| !value.is_a? Class }
+        raise ArgumentError, '`type_class_mapping` has to be a Hash with '\
+                             'symbolized keys and classes as values but is '\
+                             "`#{type_class_mapping.inspect}`"
+      end
+
+      @custom_element_exporters[exporter.to_sym] ||= {}
+      @custom_element_exporters[exporter.to_sym].merge!(type_class_mapping)
+    end
+
+    # Get custom exporter class for a given exporter and element type
+    # @param [Symbol] exporter_type
+    # @param [Symbol] element_type
+    # @return [Class|nil]
+    def exporter_for(exporter_type, element_type)
+      @custom_element_exporters.dig(exporter_type, element_type)
     end
   end
 end

--- a/lib/article_json/configuration.rb
+++ b/lib/article_json/configuration.rb
@@ -52,8 +52,8 @@ module ArticleJSON
     # @param [Symbol] exporter
     # @param [Hash[Symbol => Class]] type_class_mapping
     def register_element_exporters_for(exporter, type_class_mapping)
-      unless %i(html).include?(exporter)
-        raise ArgumentError, '`exporter` only supports `:html` '\
+      unless %i(html amp).include?(exporter)
+        raise ArgumentError, '`exporter` needs to be either `:html` or `:amp` '\
                              "but is `#{exporter.inspect}`"
       end
       if !type_class_mapping.is_a?(Hash) ||

--- a/lib/article_json/export/amp/elements/base.rb
+++ b/lib/article_json/export/amp/elements/base.rb
@@ -44,8 +44,16 @@ module ArticleJSON
 
             # Look up the correct exporter class based on the element type
             # @param [Symbol] type
-            # @return [ArticleJSON::Export::HTML::Elements::Base]
+            # @return [ArticleJSON::Export::AMP::Elements::Base]
             def exporter_by_type(type)
+              key = type.to_sym
+              ArticleJSON.configuration.exporter_for(:amp, key) ||
+                default_exporter_mapping[key]
+            end
+
+            private
+
+            def default_exporter_mapping
               {
                 text: Text,
                 paragraph: Paragraph,
@@ -55,7 +63,7 @@ module ArticleJSON
                 image: Image,
                 embed: Embed,
                 text_box: TextBox,
-              }.fetch(type.to_sym)
+              }
             end
           end
         end

--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -41,11 +41,8 @@ module ArticleJSON
             # @return [ArticleJSON::Export::HTML::Elements::Base]
             def exporter_by_type(type)
               key = type.to_sym
-              if ArticleJSON.configuration.html_element_exporter.key?(key)
-                ArticleJSON.configuration.html_element_exporter[key]
-              else
-                default_exporter_mapping[type.to_sym]
-              end
+              ArticleJSON.configuration.exporter_for(:html, key) ||
+                default_exporter_mapping[key]
             end
 
             private

--- a/spec/article_json/configuration_spec.rb
+++ b/spec/article_json/configuration_spec.rb
@@ -43,6 +43,64 @@ describe ArticleJSON::Configuration do
     end
   end
 
+  describe '#register_element_exporters_for' do
+    subject do
+      ArticleJSON.configure do |c|
+        c.register_element_exporters_for(exporter, mapping)
+      end
+    end
+    let(:exporter) { :html }
+    let(:mapping) { {} }
+
+    context 'when passed an incorrect exporter' do
+      context 'when exporter is `nil`' do
+        let(:exporter) { nil }
+
+        it 'should raise an ArgumentError' do
+          expect { subject }.to raise_error ArgumentError, /exporter/
+        end
+      end
+
+      context 'when exporter is `:foobar`' do
+        let(:exporter) { :foobar }
+
+        it 'should raise an ArgumentError' do
+          expect { subject }.to raise_error ArgumentError, /exporter/
+        end
+      end
+    end
+
+    context 'when passed an incorrect mapping' do
+      shared_examples 'for an ArgumentError due to incorrect mapping' do
+        it 'should raise an ArgumentError' do
+          expect { subject }.to raise_error ArgumentError, /type_class_mapping/
+        end
+      end
+
+      context 'which has non-symbol keys' do
+        let(:mapping) { { 42 => Object } }
+        include_examples 'for an ArgumentError due to incorrect mapping'
+      end
+
+      context 'which has non-class values' do
+        let(:mapping) { { image: 42 } }
+        include_examples 'for an ArgumentError due to incorrect mapping'
+      end
+    end
+
+    context 'with valid arguments' do
+      let(:exporter) { :html }
+      let(:mapping) { { image: Object, text: String } }
+      let(:config) { ArticleJSON.configuration }
+
+      it 'registers the correct additional exporters' do
+        expect { subject }
+          .to change { config.exporter_for(:html, :image) }.from(nil).to(Object)
+          .and change { config.exporter_for(:html, :text) }.from(nil).to(String)
+      end
+    end
+  end
+
   describe '#oembed_user_agent' do
     subject { configuration.oembed_user_agent }
 

--- a/spec/article_json/export/amp/elements/base_spec.rb
+++ b/spec/article_json/export/amp/elements/base_spec.rb
@@ -34,5 +34,20 @@ describe ArticleJSON::Export::AMP::Elements::Base do
       let(:element_type) { :text }
       it { should be ArticleJSON::Export::AMP::Elements::Text }
     end
+
+    context 'when the element was additionally registered' do
+      let(:custom_element_type) { :advertisement }
+      let(:custom_element_class) { FalseClass }
+      before do
+        ArticleJSON.configure do |c|
+          c.register_element_exporters_for(
+            :amp,
+            custom_element_type => custom_element_class
+          )
+        end
+      end
+      let(:element_type) { custom_element_type }
+      it { should eq custom_element_class }
+    end
   end
 end


### PR DESCRIPTION
For this, make defining of custom exporters in configuration generic:
By adding `ArticleJSON::Configuration#register_element_exporters_for` we can in the future allow the user to use the same method to also add custom exporters e.g. for AMP.

Adapt and deprecate the existing methods (`#register_html_element_exporter`, `#html_element_exporter`, and `#html_element_exporter=` which were defined via the `attr_accessor`) so that they still work as they currently do. These will be removed soon.

Similarly to custom HTML exporters, the user can now define custom AMP exporters by defining them as:
```ruby
ArticleJSON.configure do |config|
  config.register_element_exporters_for(
    :amp,
    image: ArticleJSON::Export::AMP::Elements::ScaledImage
  )
end
```

Also use `ArticleJSON::Configuration#exporter_for` for HTML exporter lookup. Since the `#exporter_for` method always either returns a class or `nil`, there is no need for first checking if there is a custom exporter. Instead, `||` will return the default exporter if no custom exporter is returned.