### PR TITLE
Fix NodeAnalyzer to accept quote and textbox definition as heading

### DIFF
--- a/lib/article_json/import/google_doc/html/node_analyzer.rb
+++ b/lib/article_json/import/google_doc/html/node_analyzer.rb
@@ -30,7 +30,8 @@ module ArticleJSON
           # @return [Boolean]
           def heading?
             return @is_heading if defined? @is_heading
-            @is_heading = %w(h1 h2 h3 h4 h5).include?(node.name)
+            @is_heading =
+              !quote? && !text_box? && %w(h1 h2 h3 h4 h5).include?(node.name)
           end
 
           # Check if the node is a horizontal line (i.e. `<hr>`)

--- a/spec/article_json/import/google_doc/html/node_analyzer_spec.rb
+++ b/spec/article_json/import/google_doc/html/node_analyzer_spec.rb
@@ -9,8 +9,20 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
 
     %w(h1 h2 h3 h4 h5).each do |header_tag|
       context "when the node is a <#{header_tag}>" do
-        let(:xml_fragment) { "<#{header_tag}>foo</#{header_tag}>" }
-        it { should be true }
+        context 'and it is neither a `Quote:` nor a `Textbox:` tag' do
+          let(:xml_fragment) { "<#{header_tag}>foo</#{header_tag}>" }
+          it { should be true }
+        end
+
+        context 'but it is a `Quote:` tag' do
+          let(:xml_fragment) { "<#{header_tag}>Quote:</#{header_tag}>" }
+          it { should be false }
+        end
+
+        context 'but it is a `Textbox:` tag' do
+          let(:xml_fragment) { "<#{header_tag}>Textbox:</#{header_tag}>" }
+          it { should be false }
+        end
       end
     end
 


### PR DESCRIPTION
Quotes or Text Boxes are to be defined in the Google Document as a paragraph prefixed with either the `Quote:` or the `Textbox:` word and suffixed by a horizontal line.

This commit allows the hotword to also be within a heading instead of insisting on it to be a regular paragraph.