### PR TITLE
Convert `<br>` tags in Google document to newline characters

### DIFF
--- a/lib/article_json/import/google_doc/html/node_analyzer.rb
+++ b/lib/article_json/import/google_doc/html/node_analyzer.rb
@@ -23,7 +23,7 @@ module ArticleJSON
           # @return [Boolean]
           def empty?
             return @is_empty if defined? @is_empty
-            @is_empty = node.inner_text.strip.empty? && !image? && !hr?
+            @is_empty = node.inner_text.strip.empty? && !image? && !hr? && !br?
           end
 
           # Check if the node is a header tag between <h1> and <h5>
@@ -90,6 +90,14 @@ module ArticleJSON
             @is_embed = EmbeddedParser.supported?(node)
           end
 
+          # Check if the node is a linebreak. A span only containing whitespaces
+          # and <br> tags is considered a linebreak.
+          # @return [Boolean]
+          def br?
+            return @is_br if defined? @is_br
+            @is_br = node.name == 'br' || only_includes_brs?
+          end
+
           # Determine the type of this node
           # The type is one of the elements supported by article_json.
           # @return [Symbol]
@@ -104,6 +112,19 @@ module ArticleJSON
             return :image if image?
             return :embed if embed?
             :unknown
+          end
+
+          private
+
+          # Return true if the node only contains <br> nodes and empty text
+          # @return [Boolean]
+          def only_includes_brs?
+            return false unless node.inner_text.strip.empty?
+            tags = node.children.map(&:name)
+            # Check if it only contains <br> and text nodes
+            return false unless tags.all? { |tag| %w(br text).include? tag }
+            # Check if at least one is a `<br>` node
+            tags.include?('br')
           end
         end
       end

--- a/lib/article_json/import/google_doc/html/text_parser.rb
+++ b/lib/article_json/import/google_doc/html/text_parser.rb
@@ -13,7 +13,10 @@ module ArticleJSON
           # The content of the text node, w/o any markup
           # @return [String]
           def content
-            @node.inner_text
+            @node.children
+              .map { |child| child.name == 'br' ? "\n" : child.inner_text }
+              .join('')
+              .gsub(/\s*\n\s*/, "\n") # Only keep a single consecutive linebreak
           end
 
           # Check if the text node is styled as bold

--- a/spec/article_json/import/google_doc/html/node_analyzer_spec.rb
+++ b/spec/article_json/import/google_doc/html/node_analyzer_spec.rb
@@ -84,8 +84,15 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
     end
 
     context 'when the node has only whitespaces' do
-      let(:xml_fragment) { '<p> </p>' }
-      it { should be true }
+      context 'and no line breaks' do
+        let(:xml_fragment) { '<p> </p>' }
+        it { should be true }
+      end
+
+      context 'including line breaks' do
+        let(:xml_fragment) { '<p> <br></p>' }
+        it { should be false }
+      end
     end
 
     context 'when the node has nested spans that are empty' do
@@ -251,6 +258,32 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
     context 'when the node does not contain the text to start a quote' do
       let(:xml_fragment) { '<p><span>Foo Bar:</span></p>' }
       it { should be false }
+    end
+  end
+
+  describe '#br?' do
+    subject { node.br? }
+
+    context 'when the node is a <br> itself' do
+      let(:xml_fragment) { '<br>' }
+      it { should be true }
+    end
+
+    context 'when the node is a span' do
+      context 'and contains text' do
+        let(:xml_fragment) { '<span>Foo Bar:<br></p>' }
+        it { should be false }
+      end
+
+      context 'and only contains a linebreak' do
+        let(:xml_fragment) { '<span><br></p>' }
+        it { should be true }
+      end
+
+      context 'and only contains linebreaks and spaces' do
+        let(:xml_fragment) { '<span><br>  <br> </p>' }
+        it { should be true }
+      end
     end
   end
 

--- a/spec/article_json/import/google_doc/html/text_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/text_parser_spec.rb
@@ -17,8 +17,20 @@ describe ArticleJSON::Import::GoogleDoc::HTML::TextParser do
 
   describe '#content' do
     subject { element.content }
-    let(:xml_fragment) { '<span>foo bar</span>' }
-    it { should eq 'foo bar' }
+    context 'when it only includes text' do
+      let(:xml_fragment) { '<span>foo bar</span>' }
+      it { should eq 'foo bar' }
+    end
+
+    context 'when it includes a line break' do
+      let(:xml_fragment) { '<span>foo<br>bar</span>' }
+      it { should eq "foo\nbar" }
+    end
+
+    context 'when it includes multiple consecutive line breaks' do
+      let(:xml_fragment) { '<span>foo  <br> <br>  <br>bar</span>' }
+      it { should eq "foo\nbar" }
+    end
   end
 
   describe '#bold?' do
@@ -136,13 +148,15 @@ describe ArticleJSON::Import::GoogleDoc::HTML::TextParser do
         <p>
           <span class="bold">A </span>
           <span><a href="https://devex.com">link</a></span>
-          <span class="italic"> and styling.</span>
+          <span class="italic"> and styling</span>
+          <span> with some <br>line breaks</span>
+          <span><br></span>
         </p>
       html
     end
 
     it 'parses all text sub-nodes' do
-      expect(subject.size).to eq 3
+      expect(subject.size).to eq 5
       expect(subject).to all be_a ArticleJSON::Elements::Text
 
       expect(subject[0].content).to eq 'A '
@@ -155,10 +169,20 @@ describe ArticleJSON::Import::GoogleDoc::HTML::TextParser do
       expect(subject[1].italic).to be false
       expect(subject[1].href).to eq 'https://devex.com'
 
-      expect(subject[2].content).to eq ' and styling.'
+      expect(subject[2].content).to eq ' and styling'
       expect(subject[2].bold).to be false
       expect(subject[2].italic).to be true
       expect(subject[2].href).to be nil
+
+      expect(subject[3].content).to eq " with some\nline breaks"
+      expect(subject[3].bold).to be false
+      expect(subject[3].italic).to be false
+      expect(subject[3].href).to be nil
+
+      expect(subject[4].content).to eq "\n"
+      expect(subject[4].bold).to be false
+      expect(subject[4].italic).to be false
+      expect(subject[4].href).to be nil
     end
   end
 end


### PR DESCRIPTION
If a text element from the Google document contains one (or multiple) `<br>` linebreak elements, substitute them as `"\n"` characters within the `Text` element.

For this, add `NodeAnalyzer#br?` analyzer to check if node is a `<br>` character or only contains whitespace characters and a line break.

Currently, the exporters will just ignore `"\n"` characters when rendering AMP or HTML. A following PR will add support for this to the exporters.