### PR TITLE
Add support for linebreaks in HTML exporter

### DIFF
--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -11,7 +11,7 @@ module ArticleJSON
           # Export a HTML node out of the given element
           # Dynamically looks up the right export-element-class, instantiates it
           # and then calls the #build method.
-          # @return [Nokogiri::HTML::Node]
+          # @return [Nokogiri::XML::Element]
           def export
             exporter = self.class == Base ? self.class.build(@element) : self
             exporter.export unless exporter.nil?
@@ -19,8 +19,23 @@ module ArticleJSON
 
           private
 
+          # Create a Nokogiri Node with the given `tag`
+          # @param [Symbol] tag - type of the created element
+          # @param [*Object] args - additional arguments for the element
+          # @yield [Nokogiri::XML::Element] Optional block can be passed, will
+          #                                 be executed with the generated
+          #                                 element as a parameter. Return
+          #                                 value of this method will remain the
+          #                                 main element.
+          # @return [Nokogiri::XML::Element]
           def create_element(tag, *args)
-            Nokogiri::HTML.fragment('').document.create_element(tag.to_s, *args)
+            Nokogiri::HTML
+              .fragment('')
+              .document
+              .create_element(tag.to_s, *args)
+              .tap do |element|
+                yield(element) if block_given?
+              end
           end
 
           def create_text_node(text)

--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -11,7 +11,7 @@ module ArticleJSON
           # Export a HTML node out of the given element
           # Dynamically looks up the right export-element-class, instantiates it
           # and then calls the #build method.
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             exporter = self.class == Base ? self.class.build(@element) : self
             exporter.export unless exporter.nil?
@@ -19,30 +19,38 @@ module ArticleJSON
 
           private
 
-          # Create a Nokogiri Node with the given `tag`
+          # Create a Nokogiri NodeSet wrapping a Node with the given `tag`
           # @param [Symbol] tag - type of the created element
           # @param [*Object] args - additional arguments for the element
           # @yield [Nokogiri::XML::Element] Optional block can be passed, will
           #                                 be executed with the generated
-          #                                 element as a parameter. Return
-          #                                 value of this method will remain the
-          #                                 main element.
-          # @return [Nokogiri::XML::Element]
+          #                                 element as a parameter
+          # @return [Nokogiri::XML::NodeSet] Generated main element wrapped in a
+          #                                  NodeSet
           def create_element(tag, *args)
-            Nokogiri::HTML
-              .fragment('')
-              .document
-              .create_element(tag.to_s, *args)
-              .tap do |element|
-                yield(element) if block_given?
-              end
+            document = Nokogiri::HTML.fragment('').document
+            element = document.create_element(tag.to_s, *args)
+            yield(element) if block_given?
+            wrap_in_node_set([element], document)
           end
 
+          # Wrap a given list of Nokogiri Nodes in NodeSets
+          # @param [Array[Nokogiri::XML::Node]] elements
+          # @param [Nokogiri::HTML::Document] document
+          # @return [Nokogiri::XML::NodeSet]
+          def wrap_in_node_set(elements, document)
+            Nokogiri::XML::NodeSet.new(document).tap do |node_set|
+              elements.each { |element| node_set.push(element) }
+            end
+          end
+
+          # @param [String] text
+          # @return [Nokogiri::XML::NodeSet]
           def create_text_node(text)
-            Nokogiri::HTML.fragment(text).children.first
+            Nokogiri::HTML.fragment(text).children
           end
 
-          class << self
+            class << self
             # Instantiate the correct sub class for a given element
             # @param [ArticleJSON::Elements::Base] element
             # @return [ArticleJSON::Export::HTML::Elements::Base]

--- a/lib/article_json/export/html/elements/base.rb
+++ b/lib/article_json/export/html/elements/base.rb
@@ -44,13 +44,7 @@ module ArticleJSON
             end
           end
 
-          # @param [String] text
-          # @return [Nokogiri::XML::NodeSet]
-          def create_text_node(text)
-            Nokogiri::HTML.fragment(text).children
-          end
-
-            class << self
+          class << self
             # Instantiate the correct sub class for a given element
             # @param [ArticleJSON::Elements::Base] element
             # @return [ArticleJSON::Export::HTML::Elements::Base]

--- a/lib/article_json/export/html/elements/embed.rb
+++ b/lib/article_json/export/html/elements/embed.rb
@@ -6,7 +6,7 @@ module ArticleJSON
           include Shared::Caption
 
           # Generate the embedded element node
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             create_element(:figure) do |figure|
               figure.add_child(embed_node)

--- a/lib/article_json/export/html/elements/embed.rb
+++ b/lib/article_json/export/html/elements/embed.rb
@@ -5,8 +5,10 @@ module ArticleJSON
         class Embed < Base
           include Shared::Caption
 
+          # Generate the embedded element node
+          # @return [Nokogiri::XML::Element]
           def export
-            create_element(:figure).tap do |figure|
+            create_element(:figure) do |figure|
               figure.add_child(embed_node)
               figure.add_child(caption_node(:figcaption))
             end
@@ -15,7 +17,7 @@ module ArticleJSON
           private
 
           def embed_node
-            create_element(:div, class: 'embed').tap do |div|
+            create_element(:div, class: 'embed') do |div|
               div.add_child(embedded_object)
             end
           end

--- a/lib/article_json/export/html/elements/heading.rb
+++ b/lib/article_json/export/html/elements/heading.rb
@@ -3,6 +3,8 @@ module ArticleJSON
     module HTML
       module Elements
         class Heading < Base
+          # Generate the heading element node with the right text
+          # @return [Nokogiri::XML::Element]
           def export
             create_element(tag_name, @element.content)
           end

--- a/lib/article_json/export/html/elements/image.rb
+++ b/lib/article_json/export/html/elements/image.rb
@@ -17,7 +17,7 @@ module ArticleJSON
 
           private
 
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def image_node
             create_element(:img, src: @element.source_url)
           end

--- a/lib/article_json/export/html/elements/image.rb
+++ b/lib/article_json/export/html/elements/image.rb
@@ -6,9 +6,10 @@ module ArticleJSON
           include Shared::Caption
           include Shared::Float
 
-          # @return [Nokogiri::HTML::Node]
+          # Generate the `<figure>` node containing the image and caption
+          # @return [Nokogiri::XML::Element]
           def export
-            create_element(:figure, node_opts).tap do |figure|
+            create_element(:figure, node_opts) do |figure|
               figure.add_child(image_node)
               figure.add_child(caption_node(:figcaption))
             end
@@ -16,7 +17,7 @@ module ArticleJSON
 
           private
 
-          # @return [Nokogiri::HTML::Node]
+          # @return [Nokogiri::XML::Element]
           def image_node
             create_element(:img, src: @element.source_url)
           end

--- a/lib/article_json/export/html/elements/list.rb
+++ b/lib/article_json/export/html/elements/list.rb
@@ -4,13 +4,14 @@ module ArticleJSON
       module Elements
         class List < Base
           # Generate the list node with its list elements
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             create_element(tag_name) do |list|
               @element.content.each do |child_element|
-                item = create_element(:li)
-                item.add_child(Paragraph.new(child_element).export)
-                list.add_child(item)
+                list_item_wrapper = create_element(:li) do |item|
+                  item.add_child(Paragraph.new(child_element).export)
+                end
+                list.add_child(list_item_wrapper)
               end
             end
           end

--- a/lib/article_json/export/html/elements/list.rb
+++ b/lib/article_json/export/html/elements/list.rb
@@ -3,8 +3,10 @@ module ArticleJSON
     module HTML
       module Elements
         class List < Base
+          # Generate the list node with its list elements
+          # @return [Nokogiri::XML::Element]
           def export
-            create_element(tag_name).tap do |list|
+            create_element(tag_name) do |list|
               @element.content.each do |child_element|
                 item = create_element(:li)
                 item.add_child(Paragraph.new(child_element).export)

--- a/lib/article_json/export/html/elements/paragraph.rb
+++ b/lib/article_json/export/html/elements/paragraph.rb
@@ -4,7 +4,7 @@ module ArticleJSON
       module Elements
         class Paragraph < Base
           # Generate the paragraph node with its containing text elements
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             create_element(:p) do |p|
               @element.content.each do |child_element|

--- a/lib/article_json/export/html/elements/paragraph.rb
+++ b/lib/article_json/export/html/elements/paragraph.rb
@@ -3,8 +3,10 @@ module ArticleJSON
     module HTML
       module Elements
         class Paragraph < Base
+          # Generate the paragraph node with its containing text elements
+          # @return [Nokogiri::XML::Element]
           def export
-            create_element(:p).tap do |p|
+            create_element(:p) do |p|
               @element.content.each do |child_element|
                 p.add_child(Text.new(child_element).export)
               end

--- a/lib/article_json/export/html/elements/quote.rb
+++ b/lib/article_json/export/html/elements/quote.rb
@@ -6,8 +6,10 @@ module ArticleJSON
           include Shared::Caption
           include Shared::Float
 
+          # Generate the quote node with all its containing text elements
+          # @return [Nokogiri::XML::Element]
           def export
-            create_element(:div, node_opts).tap do |div|
+            create_element(:div, node_opts) do |div|
               @element.content.each do |child_element|
                 div.add_child(Base.new(child_element).export)
               end

--- a/lib/article_json/export/html/elements/quote.rb
+++ b/lib/article_json/export/html/elements/quote.rb
@@ -7,7 +7,7 @@ module ArticleJSON
           include Shared::Float
 
           # Generate the quote node with all its containing text elements
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             create_element(:div, node_opts) do |div|
               @element.content.each do |child_element|

--- a/lib/article_json/export/html/elements/shared/caption.rb
+++ b/lib/article_json/export/html/elements/shared/caption.rb
@@ -6,7 +6,7 @@ module ArticleJSON
           module Caption
             # Generate the caption node
             # @param [String] tag_name
-            # @return [Nokogiri::XML::Element]
+            # @return [Nokogiri::XML::NodeSet]
             def caption_node(tag_name)
               create_element(tag_name) do |caption|
                 @element.caption.each do |child_element|

--- a/lib/article_json/export/html/elements/shared/caption.rb
+++ b/lib/article_json/export/html/elements/shared/caption.rb
@@ -6,9 +6,9 @@ module ArticleJSON
           module Caption
             # Generate the caption node
             # @param [String] tag_name
-            # @return [Nokogiri::HTML::Node]
+            # @return [Nokogiri::XML::Element]
             def caption_node(tag_name)
-              create_element(tag_name).tap do |caption|
+              create_element(tag_name) do |caption|
                 @element.caption.each do |child_element|
                   caption.add_child(Text.new(child_element).export)
                 end

--- a/lib/article_json/export/html/elements/text.rb
+++ b/lib/article_json/export/html/elements/text.rb
@@ -5,7 +5,7 @@ module ArticleJSON
         class Text < Base
           # Generate a Nokogiri node or simple text node, depending on the text
           # options
-          # @return [Nokogiri::XML::Element|Nokogiri::XML::Text]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             return bold_and_italic_node if @element.bold && @element.italic
             return bold_node if @element.bold
@@ -15,26 +15,26 @@ module ArticleJSON
 
           private
 
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def italic_node
             create_element(:em) { |em| em.add_child(content_node) }
           end
 
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def bold_node
             create_element(:strong) do |strong|
               strong.add_child(content_node)
             end
           end
 
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def bold_and_italic_node
             create_element(:strong) do |strong|
               strong.add_child(italic_node)
             end
           end
 
-          # @return [Nokogiri::XML::Element|Nokogiri::XML::Text]
+          # @return [Nokogiri::XML::NodeSet]
           def content_node
             return create_text_node(@element.content) if @element.href.nil?
             create_element(:a, @element.content, href: @element.href)

--- a/lib/article_json/export/html/elements/text.rb
+++ b/lib/article_json/export/html/elements/text.rb
@@ -3,7 +3,9 @@ module ArticleJSON
     module HTML
       module Elements
         class Text < Base
-          # @return [Nokogiri::HTML::Node]
+          # Generate a Nokogiri node or simple text node, depending on the text
+          # options
+          # @return [Nokogiri::XML::Element|Nokogiri::XML::Text]
           def export
             return bold_and_italic_node if @element.bold && @element.italic
             return bold_node if @element.bold
@@ -13,26 +15,26 @@ module ArticleJSON
 
           private
 
-          # @return [Nokogiri::HTML::Node]
+          # @return [Nokogiri::XML::Element]
           def italic_node
-            create_element(:em).tap { |em| em.add_child(content_node) }
+            create_element(:em) { |em| em.add_child(content_node) }
           end
 
-          # @return [Nokogiri::HTML::Node]
+          # @return [Nokogiri::XML::Element]
           def bold_node
-            create_element(:strong).tap do |strong|
+            create_element(:strong) do |strong|
               strong.add_child(content_node)
             end
           end
 
-          # @return [Nokogiri::HTML::Node]
+          # @return [Nokogiri::XML::Element]
           def bold_and_italic_node
-            create_element(:strong).tap do |strong|
+            create_element(:strong) do |strong|
               strong.add_child(italic_node)
             end
           end
 
-          # @return [Nokogiri::HTML::Node]
+          # @return [Nokogiri::XML::Element|Nokogiri::XML::Text]
           def content_node
             return create_text_node(@element.content) if @element.href.nil?
             create_element(:a, @element.content, href: @element.href)

--- a/lib/article_json/export/html/elements/text.rb
+++ b/lib/article_json/export/html/elements/text.rb
@@ -36,8 +36,17 @@ module ArticleJSON
 
           # @return [Nokogiri::XML::NodeSet]
           def content_node
-            return create_text_node(@element.content) if @element.href.nil?
-            create_element(:a, @element.content, href: @element.href)
+            return create_text_nodes(@element.content) if @element.href.nil?
+            create_element(:a, href: @element.href) do |a|
+              a.add_child(create_text_nodes(@element.content))
+            end
+          end
+
+          # @param [Nokogiri::HTML::NodeSet] text
+          def create_text_nodes(text)
+            Nokogiri::HTML
+              .fragment(text.gsub(/\n/, '<br>'))
+              .children
           end
         end
       end

--- a/lib/article_json/export/html/elements/text_box.rb
+++ b/lib/article_json/export/html/elements/text_box.rb
@@ -6,7 +6,7 @@ module ArticleJSON
           include Shared::Float
 
           # Generate a `<div>` node containing all text box elements
-          # @return [Nokogiri::XML::Element]
+          # @return [Nokogiri::XML::NodeSet]
           def export
             create_element(:div, node_opts) do |div|
               @element.content.each do |child_element|

--- a/lib/article_json/export/html/elements/text_box.rb
+++ b/lib/article_json/export/html/elements/text_box.rb
@@ -5,8 +5,10 @@ module ArticleJSON
         class TextBox < Base
           include Shared::Float
 
+          # Generate a `<div>` node containing all text box elements
+          # @return [Nokogiri::XML::Element]
           def export
-            create_element(:div, node_opts).tap do |div|
+            create_element(:div, node_opts) do |div|
               @element.content.each do |child_element|
                 div.add_child(Base.new(child_element).export)
               end

--- a/spec/article_json/export/html/elements/text_spec.rb
+++ b/spec/article_json/export/html/elements/text_spec.rb
@@ -3,12 +3,13 @@ describe ArticleJSON::Export::HTML::Elements::Text do
 
   let(:source_element) do
     ArticleJSON::Elements::Text.new(
-      content: 'Foo Bar',
+      content: content,
       bold: bold,
       italic: italic,
       href: href
     )
   end
+  let(:content) { 'Foo Bar' }
   let(:bold) { false }
   let(:italic) { false }
   let(:href) { nil }
@@ -18,6 +19,11 @@ describe ArticleJSON::Export::HTML::Elements::Text do
 
     context 'when the source element is plain text' do
       it { should eq 'Foo Bar' }
+    end
+
+    context 'when the source element contains a newline character' do
+      let(:content) { "Foo\nBar" }
+      it { should eq 'Foo<br>Bar' }
     end
 
     context 'when the source element is bold text' do


### PR DESCRIPTION
If the element content contains `"\n"` characters these will be transformed to `<br>` HTML tags.

For this, ensure that all `#export` return a `Nokogiri::XML::NodeSet` so that multiple nodes are supported as a return value. Therefore, change `Base#create_element` to wrap the generated element in a `NodeSet` and allow passing a block to the method to add additional fields onto the wrapped element (this avoids having to `tap` the element and then access the first element in the node set).

For more details, please refer to the individual commit messages.

RFC @dsager & @towanda