### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Changelog
 
-## ? - WIP
-- Configurable HTML and AMP element exporters
+## 0.2.0 - 2017/11/03
+In this second release we **added support** to:
+- Export AMP along with required libraries for AMP rendering
+- Configure custom HTML and AMP element exporters
 - Resolve oembed elements in HTML export
+
+One potentially **breaking change** was added:
 - Export quotes as `<div>` instead of `<aside>`
-- Make Google Parser more fault tolerant
+
+**Fixes**:
 - Support Vimeo videos with old flash player URLs
-- Export AMP
-- Return required libraries for AMP rendering
+- Make Google Parser more fault tolerant
+- Respect linebreaks when importing Google Docs
+- Export linebreaks in JSON to `<br>` tags in HTML / AMP
 
 ## 0.1.0 - 2017/09/20
 This is the very first release, with the following functionality:

--- a/article_json.gemspec
+++ b/article_json.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version = ArticleJSON::VERSION
   s.platform = Gem::Platform::RUBY
 
-  s.authors = %w(@dsager)
+  s.authors = ['Daniel Sager', 'Manu Campos', 'Nicolas Fricke']
   s.email = 'info@devex.com'
   s.homepage = 'https://github.com/Devex/article_json'
   s.license = 'MIT'

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/article_json/article_spec.rb
+++ b/spec/article_json/article_spec.rb
@@ -75,7 +75,7 @@ describe ArticleJSON::Article do
   shared_context 'for a correctly parsed Hash' do
     let(:example_hash) do
       {
-        article_json_version: '0.1.0',
+        article_json_version: '0.2.0',
         content: [
           {
             type: :paragraph,

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.1.0",
+  "article_json_version": "0.2.0",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
In this second release we **added support** to:
- Export AMP along with required libraries for AMP rendering
- Configure custom HTML and AMP element exporters
- Resolve oembed elements in HTML export

One potentially **breaking change** was added:
- Export quotes as `<div>` instead of `<aside>`

**Fixes**:
- Support Vimeo videos with old flash player URLs
- Make Google Parser more fault tolerant
- Respect linebreaks when importing Google Docs
- Export linebreaks in JSON to `<br>` tags in HTML / AMP

Also add @towanda and myself as gem authors to the gemspec and change authors to contain clear names instead of Github handle (since this is [the community standard](http://guides.rubygems.org/specification-reference/#authors=))