### PR TITLE
Handle bad OEmbed responses and return message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## WIP
+- Handle non-successful OEmbed responses
+
 ## 0.2.0 - 2017/11/03
 In this second release we **added support** to:
 - Export AMP along with required libraries for AMP rendering

--- a/lib/article_json/elements/embed.rb
+++ b/lib/article_json/elements/embed.rb
@@ -28,7 +28,7 @@ module ArticleJSON
       end
 
       # Obtain the oembed data for this embed element
-      # @return [Hash]
+      # @return [Hash|nil]
       def oembed_data
         oembed_resolver&.oembed_data
       end

--- a/lib/article_json/elements/embed.rb
+++ b/lib/article_json/elements/embed.rb
@@ -33,6 +33,11 @@ module ArticleJSON
         oembed_resolver&.oembed_data
       end
 
+      # @return [Array[ArticleJSON::Elements::Text]|nil]
+      def oembed_unavailable_message
+        oembed_resolver&.unavailable_message
+      end
+
       private
 
       # @return [ArticleJSON::Utils::OEmbedResolver::Base]

--- a/lib/article_json/export/common/html/elements/embed.rb
+++ b/lib/article_json/export/common/html/elements/embed.rb
@@ -19,11 +19,12 @@ module ArticleJSON
 
             def embed_node
               create_element(:div, class: 'embed') do |div|
-                div.add_child(embedded_object)
+                div.add_child(embedded_object) if embedded_object
               end
             end
 
             def embedded_object
+              return unless @element.oembed_data
               Nokogiri::HTML.fragment(@element.oembed_data[:html])
             end
           end

--- a/lib/article_json/export/common/html/elements/embed.rb
+++ b/lib/article_json/export/common/html/elements/embed.rb
@@ -19,13 +19,21 @@ module ArticleJSON
 
             def embed_node
               create_element(:div, class: 'embed') do |div|
-                div.add_child(embedded_object) if embedded_object
+                div.add_child(embedded_object)
               end
             end
 
             def embedded_object
-              return unless @element.oembed_data
+              return unavailable_node unless @element.oembed_data
               Nokogiri::HTML.fragment(@element.oembed_data[:html])
+            end
+
+            def unavailable_node
+              create_element(:span, class: 'unavailable-embed') do |span|
+                @element.oembed_unavailable_message.each do |element|
+                  span.add_child(base_class.build(element).export)
+                end
+              end
             end
           end
         end

--- a/lib/article_json/utils/o_embed_resolver/base.rb
+++ b/lib/article_json/utils/o_embed_resolver/base.rb
@@ -16,6 +16,28 @@ module ArticleJSON
           resolver.parsed_api_response
         end
 
+        # In case that there was an error with requesting the OEmbed data from
+        # the endpoint (e.g. because the URL is unavailable), this message can
+        # be rendered to let the user know about the issue
+        # @return [Array[ArticleJSON::Elements::Text]|nil]
+        def unavailable_message
+          [
+            ArticleJSON::Elements::Text.new(content: "The #{name} "),
+            ArticleJSON::Elements::Text.new(content: source_url,
+                                            href: source_url),
+            ArticleJSON::Elements::Text.new(content: ' is not available.'),
+          ]
+        end
+
+        def name
+          raise NotImplementedError,
+                '`#name` needs to be implemented by the subclass'
+        end
+
+        def source_url
+          raise NotImplementedError,
+                '`#source_url` needs to be implemented by the subclass'
+        end
 
         protected
 

--- a/lib/article_json/utils/o_embed_resolver/facebook_video.rb
+++ b/lib/article_json/utils/o_embed_resolver/facebook_video.rb
@@ -2,17 +2,21 @@ module ArticleJSON
   module Utils
     module OEmbedResolver
       class FacebookVideo < Base
+        # Human readable name of the resolver
+        # @return [String]
+        def name
+          'Facebook video'
+        end
+
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
-          "https://www.facebook.com/plugins/video/oembed.json?url=#{video_url}"
+          "https://www.facebook.com/plugins/video/oembed.json?url=#{source_url}"
         end
-
-        private
 
         # The video URL of the element
         # @return [String]
-        def video_url
+        def source_url
           "https://www.facebook.com/facebook/videos/#{@element.embed_id}"
         end
       end

--- a/lib/article_json/utils/o_embed_resolver/slideshare.rb
+++ b/lib/article_json/utils/o_embed_resolver/slideshare.rb
@@ -2,17 +2,22 @@ module ArticleJSON
   module Utils
     module OEmbedResolver
       class Slideshare < Base
+        # Human readable name of the resolver
+        # @return [String]
+        def name
+          'Slideshare deck'
+        end
+
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
-          "https://www.slideshare.net/api/oembed/2?format=json&url=#{slide_url}"
+          'https://www.slideshare.net/api/oembed/2?format=json&url='\
+          "#{source_url}"
         end
-
-        private
 
         # The URL of the slideshow
         # @return [String]
-        def slide_url
+        def source_url
           handle, slug = @element.embed_id.split('/', 2)
           "https://www.slideshare.net/#{handle}/#{slug}"
         end

--- a/lib/article_json/utils/o_embed_resolver/tweet.rb
+++ b/lib/article_json/utils/o_embed_resolver/tweet.rb
@@ -2,18 +2,22 @@ module ArticleJSON
   module Utils
     module OEmbedResolver
       class Tweet < Base
+        # Human readable name of the resolver
+        # @return [String]
+        def name
+          'Tweet'
+        end
+
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
           'https://api.twitter.com/1/statuses/oembed.json?align=center' \
-            "&url=#{tweet_url}"
+            "&url=#{source_url}"
         end
-
-        private
 
         # The URL of the tweet
         # @return [String]
-        def tweet_url
+        def source_url
           handle, tweet_id = @element.embed_id.split('/', 2)
           "https://twitter.com/#{handle}/status/#{tweet_id}"
         end

--- a/lib/article_json/utils/o_embed_resolver/vimeo_video.rb
+++ b/lib/article_json/utils/o_embed_resolver/vimeo_video.rb
@@ -2,17 +2,21 @@ module ArticleJSON
   module Utils
     module OEmbedResolver
       class VimeoVideo < Base
+        # Human readable name of the resolver
+        # @return [String]
+        def name
+          'Vimeo video'
+        end
+
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
-          "https://vimeo.com/api/oembed.json?url=#{video_url}"
+          "https://vimeo.com/api/oembed.json?url=#{source_url}"
         end
-
-        private
 
         # The video URL of the element
         # @return [String]
-        def video_url
+        def source_url
           "https://vimeo.com/#{@element.embed_id}"
         end
       end

--- a/lib/article_json/utils/o_embed_resolver/youtube_video.rb
+++ b/lib/article_json/utils/o_embed_resolver/youtube_video.rb
@@ -2,17 +2,21 @@ module ArticleJSON
   module Utils
     module OEmbedResolver
       class YoutubeVideo < Base
+        # Human readable name of the resolver
+        # @return [String]
+        def name
+          'Youtube video'
+        end
+
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
-          "http://www.youtube.com/oembed?format=json&url=#{video_url}"
+          "http://www.youtube.com/oembed?format=json&url=#{source_url}"
         end
-
-        private
 
         # The video URL of the element
         # @return [String]
-        def video_url
+        def source_url
           "https://www.youtube.com/watch?v=#{@element.embed_id}"
         end
       end

--- a/spec/article_json/export/html/elements/embed_spec.rb
+++ b/spec/article_json/export/html/elements/embed_spec.rb
@@ -1,9 +1,10 @@
 describe ArticleJSON::Export::HTML::Elements::Embed do
   subject(:element) { described_class.new(source_element) }
 
+  let(:embed_type) { :something }
   let(:source_element) do
     ArticleJSON::Elements::Embed.new(
-      embed_type: :something,
+      embed_type: embed_type,
       embed_id: 666,
       caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
       tags: %w(test)
@@ -12,14 +13,32 @@ describe ArticleJSON::Export::HTML::Elements::Embed do
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
-    let(:expected_html) do
-      '<figure><div class="embed">Embedded Object: something-666</div>' \
-        '<figcaption>Foo Bar</figcaption></figure>'
+
+    context 'when the endpoint successfully returns OEmbed data' do
+      let(:expected_html) do
+        '<figure><div class="embed">Embedded Object: something-666</div>' \
+          '<figcaption>Foo Bar</figcaption></figure>'
+      end
+      let(:oembed_data) { { html: 'Embedded Object: something-666' } }
+      before do
+        allow(source_element).to receive(:oembed_data).and_return(oembed_data)
+      end
+      it { should eq expected_html }
     end
-    let(:oembed_data) { { html: 'Embedded Object: something-666' } }
-    before do
-      allow(source_element).to receive(:oembed_data).and_return(oembed_data)
+
+    context 'when the endpoint does not return OEmbed data' do
+      let(:embed_type) { :youtube_video }
+      let(:expected_html) do
+        '<figure><div class="embed"><span class="unavailable-embed">'\
+        'The Youtube video <a href="https://www.youtube.com/watch?v=666">'\
+        'https://www.youtube.com/watch?v=666</a> is not available.</span>'\
+        '</div><figcaption>Foo Bar</figcaption></figure>'
+      end
+      let(:oembed_data) { { html: 'Embedded Object: something-666' } }
+      before do
+        allow(source_element).to receive(:oembed_data).and_return(nil)
+      end
+      it { should eq expected_html }
     end
-    it { should eq expected_html }
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/base_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/base_spec.rb
@@ -1,6 +1,8 @@
 describe ArticleJSON::Utils::OEmbedResolver::Base do
   subject(:resolver) { described_class.new(element) }
 
+  let(:embed_id) { 'ABC' }
+  let(:embed_type) { :foobar }
   let(:element) do
     ArticleJSON::Elements::Embed.new(
       embed_type: embed_type,
@@ -12,8 +14,6 @@ describe ArticleJSON::Utils::OEmbedResolver::Base do
   describe '#oembed_data' do
     subject { resolver.oembed_data }
 
-    let(:embed_id) { 'ABC' }
-    let(:embed_type) { :foobar }
     let(:something_resolver) { double('something resolver') }
     let(:oembed_data) { { foo: :bar } }
 
@@ -25,6 +25,39 @@ describe ArticleJSON::Utils::OEmbedResolver::Base do
     end
 
     it { should eq oembed_data }
+  end
+
+  describe '#unavailable_message' do
+    subject { resolver.unavailable_message }
+    let(:name) { 'Embed type' }
+    let(:source_url) { 'https://example.com' }
+    before do
+      allow(resolver).to receive(:name).and_return(name)
+      allow(resolver).to receive(:source_url).and_return(source_url)
+    end
+    it { should_not be_nil }
+
+    it 'should return an Array of Text elements' do
+      is_expected.to be_an Array
+      is_expected.to all be_a ArticleJSON::Elements::Text
+      expect(subject.size).to eq 3
+      expect(subject[0].content).to include name
+      expect(subject[1].content).to eq source_url
+      expect(subject[1].href).to eq source_url
+      expect(subject[2].content).to include 'not available'
+    end
+  end
+
+  describe '#name' do
+    it 'should raise a NotImplementedError' do
+      expect { resolver.name }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#source_url' do
+    it 'should raise a NotImplementedError' do
+      expect { resolver.source_url }.to raise_error NotImplementedError
+    end
   end
 
   describe '.build' do

--- a/spec/article_json/utils/o_embed_resolver/facebook_video_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/facebook_video_spec.rb
@@ -16,5 +16,6 @@ describe ArticleJSON::Utils::OEmbedResolver::FacebookVideo do
     let(:oembed_response) do
       File.read('spec/fixtures/facebook_video_oembed.json')
     end
+    let(:expected_name) { 'Facebook video' }
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/oembed_resolver_shared.rb
+++ b/spec/article_json/utils/o_embed_resolver/oembed_resolver_shared.rb
@@ -11,18 +11,30 @@ shared_context 'for a successful oembed resolution' do
 
     let(:expected_response) { JSON.parse(oembed_response, symbolize_names: 1) }
 
-    before { stub_oembed_requests }
+    context 'when the source responds successfully' do
+      before { stub_oembed_requests }
 
-    context 'with no additional headers' do
-      it { should eq expected_response }
+      context 'with no additional headers' do
+        it { should eq expected_response }
+      end
+
+      context 'with additional headers' do
+        before do
+          ArticleJSON.configure { |c| c.oembed_user_agent = 'foobar' }
+          stub_oembed_requests('User-Agent' => 'foobar')
+        end
+        it { should eq expected_response }
+      end
     end
 
-    context 'with additional headers' do
-      before do
-        ArticleJSON.configure { |c| c.oembed_user_agent = 'foobar' }
-        stub_oembed_requests('User-Agent' => 'foobar')
-      end
-      it { should eq expected_response }
+    context 'when the source returns no body' do
+      before { stub_oembed_requests(custom_body: '') }
+      it { should eq nil }
+    end
+
+    context 'when the source returns an error code' do
+      before { stub_oembed_requests(error: true) }
+      it { should eq nil }
     end
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/oembed_resolver_shared.rb
+++ b/spec/article_json/utils/o_embed_resolver/oembed_resolver_shared.rb
@@ -1,6 +1,12 @@
 shared_context 'for a successful oembed resolution' do
   subject(:resolver) { described_class.new(element) }
 
+  describe '#name' do
+    subject { resolver.name }
+    it { should be_a String }
+    it { should eq expected_name }
+  end
+
   describe '#oembed_url' do
     subject { resolver.oembed_url }
     it { should eq expected_oembed_url }
@@ -36,5 +42,11 @@ shared_context 'for a successful oembed resolution' do
       before { stub_oembed_requests(error: true) }
       it { should eq nil }
     end
+  end
+
+  describe '#source_url' do
+    subject { resolver.source_url }
+    it { should be_a String }
+    it { should start_with 'http' }
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/slideshare_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/slideshare_spec.rb
@@ -14,5 +14,6 @@ describe ArticleJSON::Utils::OEmbedResolver::Slideshare do
         'https://www.slideshare.net/Devex/the-best-global-development-quotes-of-2012'
     end
     let(:oembed_response) { File.read('spec/fixtures/slideshare_oembed.json') }
+    let(:expected_name) { 'Slideshare deck' }
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/tweet_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/tweet_spec.rb
@@ -16,5 +16,6 @@ describe ArticleJSON::Utils::OEmbedResolver::Tweet do
     let(:oembed_response) do
       File.read('spec/fixtures/tweet_oembed.json')
     end
+    let(:expected_name) { 'Tweet' }
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/vimeo_video_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/vimeo_video_spec.rb
@@ -13,5 +13,6 @@ describe ArticleJSON::Utils::OEmbedResolver::VimeoVideo do
       'https://vimeo.com/api/oembed.json?url=https://vimeo.com/42315417'
     end
     let(:oembed_response) { File.read('spec/fixtures/vimeo_video_oembed.json') }
+    let(:expected_name) { 'Vimeo video' }
   end
 end

--- a/spec/article_json/utils/o_embed_resolver/youtube_video_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/youtube_video_spec.rb
@@ -16,5 +16,6 @@ describe ArticleJSON::Utils::OEmbedResolver::YoutubeVideo do
     let(:oembed_response) do
       File.read('spec/fixtures/youtube_video_oembed.json')
     end
+    let(:expected_name) { 'Youtube video' }
   end
 end

--- a/spec/support/oembed_request_mocks.rb
+++ b/spec/support/oembed_request_mocks.rb
@@ -1,58 +1,81 @@
 module OembedRequestStubs
-  def stub_oembed_requests(additional_headers = {})
-    stub_oembed_facebook_request(additional_headers)
-    stub_oembed_vimeo_request(additional_headers)
-    stub_oembed_youtube_request(additional_headers)
-    stub_oembed_slideshare_request(additional_headers)
-    stub_oembed_tweet_request(additional_headers)
+  def stub_oembed_requests(additional_headers = {}, custom_body: nil,
+                           error: false)
+    stub_oembed_facebook_request(additional_headers,
+                                 custom_body: custom_body,
+                                 error: error)
+    stub_oembed_vimeo_request(additional_headers,
+                              custom_body: custom_body,
+                              error: error)
+    stub_oembed_youtube_request(additional_headers,
+                                custom_body: custom_body,
+                                error: error)
+    stub_oembed_slideshare_request(additional_headers,
+                                   custom_body: custom_body,
+                                   error: error)
+    stub_oembed_tweet_request(additional_headers,
+                              custom_body: custom_body,
+                              error: error)
   end
 
-  def stub_oembed_facebook_request(additional_headers = {})
+  def stub_oembed_facebook_request(additional_headers = {}, custom_body: nil,
+                                   error: false)
     stub_oembed_request(
       'https://www.facebook.com/plugins/video/oembed.json?url=https://www.facebook.com/facebook/videos/1814600831891266',
-      'facebook_video_oembed',
-      additional_headers
+      custom_body || File.read('spec/fixtures/facebook_video_oembed.json'),
+      additional_headers,
+      error: error
     )
   end
 
-  def stub_oembed_vimeo_request(additional_headers = {})
+  def stub_oembed_vimeo_request(additional_headers = {}, custom_body: nil,
+                                error: false)
     stub_oembed_request(
       'https://vimeo.com/api/oembed.json?url=https://vimeo.com/42315417',
-      'vimeo_video_oembed',
-      additional_headers
+      custom_body || File.read('spec/fixtures/vimeo_video_oembed.json'),
+      additional_headers,
+      error: error
     )
   end
 
-  def stub_oembed_youtube_request(additional_headers = {})
+  def stub_oembed_youtube_request(additional_headers = {}, custom_body: nil,
+                                  error: false)
     stub_oembed_request(
       'http://www.youtube.com/oembed?format=json&url=https://www.youtube.com/watch?v=_ZG8HBuDjgc',
-      'youtube_video_oembed',
-      additional_headers
+      custom_body || File.read('spec/fixtures/youtube_video_oembed.json'),
+      additional_headers,
+      error: error
     )
   end
 
-  def stub_oembed_slideshare_request(additional_headers = {})
+  def stub_oembed_slideshare_request(additional_headers = {}, custom_body: nil,
+                                     error: false)
     stub_oembed_request(
       'https://www.slideshare.net/api/oembed/2?format=json&url=https://www.slideshare.net/Devex/the-best-global-development-quotes-of-2012',
-      'slideshare_oembed',
-      additional_headers
+      custom_body || File.read('spec/fixtures/slideshare_oembed.json'),
+      additional_headers,
+      error: error
     )
   end
 
-  def stub_oembed_tweet_request(additional_headers = {})
+  def stub_oembed_tweet_request(additional_headers = {}, custom_body: nil,
+                                error: false)
     stub_oembed_request(
       'https://api.twitter.com/1/statuses/oembed.json?align=center&url=https://twitter.com/d3v3x/status/554608639030599681',
-      'tweet_oembed',
-      additional_headers
+      custom_body || File.read('spec/fixtures/tweet_oembed.json'),
+      additional_headers,
+      error: error
     )
   end
 
-  def stub_oembed_request(url, fixture, additional_headers)
+  def stub_oembed_request(url, body, additional_headers, custom_body: nil,
+                          error: false)
     headers = { 'Content-Type' => 'application/json' }.merge(additional_headers)
-    stub_request(:get, url)
-      .with(headers: headers)
-      .to_return(
-        body: File.read("spec/fixtures/#{fixture}.json")
-      )
+    stub = stub_request(:get, url).with(headers: headers)
+    if error
+      stub.to_return(status: 400, body: 'Unavailable')
+    else
+      stub.to_return(status: 200, body: body)
+    end
   end
 end


### PR DESCRIPTION
When requesting an OEmbed object, handle the situation that the provider might return a non-successful response. In that case, render a message for the user explaining that there was an error with the embedded element.

For this, standardize the `OEbedResolver::Base#source_url` method and add a `#name` method which will be included in the text for the user.

The text for the user will be rendered within the `<figure>` element within a nested `span` with the class `unavailable-embed`. This also allows the consumer to have custom CSS for this case.