### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## WIP
-- Handle non-successful OEmbed responses
+## 0.2.1 - 2017/11/08
+**Fix**: Handle non-successful OEmbed responses by rendering message
 
 ## 0.2.0 - 2017/11/03
 In this second release we **added support** to:

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/article_json/article_spec.rb
+++ b/spec/article_json/article_spec.rb
@@ -75,7 +75,7 @@ describe ArticleJSON::Article do
   shared_context 'for a correctly parsed Hash' do
     let(:example_hash) do
       {
-        article_json_version: '0.2.0',
+        article_json_version: '0.2.1',
         content: [
           {
             type: :paragraph,

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.2.0",
+  "article_json_version": "0.2.1",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
This release is only fixing issues with bad OEmbed responses which previously caused the entire exporting of the article to fail. Now it will render a message instead of the embedded element telling the viewer that the embedded element could not be loaded.