### PR TITLE
Improve support of empty captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 - Start work on Facebook Instant Article exporter
 - Add support to exporters for `caption` elements that are an empty array
+- GDoc Importer: Support `[no-caption]` text, returns empty caption for element
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 - Start work on Facebook Instant Article exporter
+- Add support to exporters for `caption` elements that are an empty array
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/lib/article_json/export/common/html/elements/embed.rb
+++ b/lib/article_json/export/common/html/elements/embed.rb
@@ -11,7 +11,9 @@ module ArticleJSON
             def export
               create_element(:figure) do |figure|
                 figure.add_child(embed_node)
-                figure.add_child(caption_node(:figcaption))
+                if @element.caption&.any?
+                  figure.add_child(caption_node(:figcaption))
+                end
               end
             end
 

--- a/lib/article_json/export/common/html/elements/image.rb
+++ b/lib/article_json/export/common/html/elements/image.rb
@@ -12,7 +12,9 @@ module ArticleJSON
             def export
               create_element(:figure, node_opts) do |figure|
                 figure.add_child(image_node)
-                figure.add_child(caption_node(:figcaption))
+                if @element.caption&.any?
+                  figure.add_child(caption_node(:figcaption))
+                end
               end
             end
 

--- a/lib/article_json/export/common/html/elements/quote.rb
+++ b/lib/article_json/export/common/html/elements/quote.rb
@@ -14,7 +14,9 @@ module ArticleJSON
                 @element.content.each do |child_element|
                   div.add_child(base_class.new(child_element).export)
                 end
-                div.add_child(caption_node(caption_tag))
+                if @element.caption&.any?
+                  div.add_child(caption_node(caption_tag))
+                end
               end
             end
 

--- a/lib/article_json/import/google_doc/html/shared/caption.rb
+++ b/lib/article_json/import/google_doc/html/shared/caption.rb
@@ -7,7 +7,7 @@ module ArticleJSON
             # Parse the caption node
             # @return [Array[ArticleJSON::Elements::Text]]
             def caption
-              return empty_caption if @caption_node.nil?
+              return [] if no_caption?
               ArticleJSON::Import::GoogleDoc::HTML::TextParser.extract(
                 node: @caption_node,
                 css_analyzer: @css_analyzer
@@ -16,8 +16,9 @@ module ArticleJSON
 
             private
 
-            def empty_caption
-              [ArticleJSON::Elements::Text.new(content: '&nbsp;')]
+            def no_caption?
+              @caption_node.nil? ||
+                @caption_node.inner_text.strip == '[no-caption]'
             end
           end
         end

--- a/spec/article_json/export/amp/elements/embed_spec.rb
+++ b/spec/article_json/export/amp/elements/embed_spec.rb
@@ -5,10 +5,11 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
     ArticleJSON::Elements::Embed.new(
       embed_type: source_element_embed_type,
       embed_id: 666,
-      caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
+      caption: caption,
       tags: %w(test)
     )
   end
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -95,6 +96,18 @@ describe ArticleJSON::Export::AMP::Elements::Embed do
       before do
         allow(source_element).to receive(:oembed_data).and_return(oembed_data)
       end
+      it { should eq expected_html }
+    end
+
+    context 'with no caption' do
+      let(:source_element_embed_type) { :youtube_video }
+      let(:caption) { [] }
+      let(:expected_html) do
+        '<figure><div class="embed">' \
+        '<amp-youtube data-videoid="666" width="560" height="315">' \
+        '</amp-youtube></div></figure>'
+      end
+
       it { should eq expected_html }
     end
   end

--- a/spec/article_json/export/amp/elements/image_spec.rb
+++ b/spec/article_json/export/amp/elements/image_spec.rb
@@ -4,12 +4,12 @@ describe ArticleJSON::Export::AMP::Elements::Image do
   let(:source_element) do
     ArticleJSON::Elements::Image.new(
       source_url: '/foo/bar.jpg',
-      caption: [caption],
+      caption: caption,
       float: float
     )
   end
   let(:float) { nil }
-  let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -39,6 +39,15 @@ describe ArticleJSON::Export::AMP::Elements::Image do
         '<figure class="float-right"><amp-img src="/foo/bar.jpg" ' \
         'width="640" height="480" layout="responsive">' \
         '</amp-img><figcaption>Foo Bar</figcaption></figure>'
+      end
+      it { should eq expected_html }
+    end
+
+    context 'when no caption is provided' do
+      let(:caption) { [] }
+      let(:expected_html) do
+        '<figure><amp-img src="/foo/bar.jpg" width="640" height="480" '\
+        'layout="responsive"></amp-img></figure>'
       end
       it { should eq expected_html }
     end

--- a/spec/article_json/export/amp/elements/quote_spec.rb
+++ b/spec/article_json/export/amp/elements/quote_spec.rb
@@ -8,10 +8,12 @@ describe ArticleJSON::Export::AMP::Elements::Quote do
           content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
         ),
       ],
-      caption: [ArticleJSON::Elements::Text.new(content: 'Baz')],
+      caption: caption,
       float: float
     )
   end
+  let(:float) { nil }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Baz')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -38,6 +40,11 @@ describe ArticleJSON::Export::AMP::Elements::Quote do
         '<div class="quote float-right"><p>Foo Bar</p><small>Baz</small></div>'
       end
       it { should eq expected_html }
+    end
+
+    context 'when no caption is present' do
+      let(:caption) { [] }
+      it { should eq '<div class="quote"><p>Foo Bar</p></div>' }
     end
   end
 end

--- a/spec/article_json/export/facebook_instant_article/elements/embed_spec.rb
+++ b/spec/article_json/export/facebook_instant_article/elements/embed_spec.rb
@@ -5,21 +5,34 @@ describe ArticleJSON::Export::FacebookInstantArticle::Elements::Embed do
     ArticleJSON::Elements::Embed.new(
       embed_type: :something,
       embed_id: 666,
-      caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
+      caption: caption,
       tags: %w(test)
     )
   end
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
-    let(:expected_html) do
-      '<figure><div class="embed">Embedded Object: something-666</div>' \
-        '<figcaption>Foo Bar</figcaption></figure>'
-    end
     let(:oembed_data) { { html: 'Embedded Object: something-666' } }
     before do
       allow(source_element).to receive(:oembed_data).and_return(oembed_data)
     end
-    it { should eq expected_html }
+
+    context 'with a proper caption' do
+      let(:expected_html) do
+        '<figure><div class="embed">Embedded Object: something-666</div>' \
+          '<figcaption>Foo Bar</figcaption></figure>'
+      end
+      it { should eq expected_html }
+    end
+
+    context 'without a proper caption' do
+      let(:caption) { [] }
+      let(:expected_html) do
+        '<figure><div class="embed">Embedded Object: something-666</div>' \
+          '</figure>'
+      end
+      it { should eq expected_html }
+    end
   end
 end

--- a/spec/article_json/export/facebook_instant_article/elements/image_spec.rb
+++ b/spec/article_json/export/facebook_instant_article/elements/image_spec.rb
@@ -4,12 +4,12 @@ describe ArticleJSON::Export::FacebookInstantArticle::Elements::Image do
   let(:source_element) do
     ArticleJSON::Elements::Image.new(
       source_url: '/foo/bar.jpg',
-      caption: [caption],
+      caption: caption,
       float: float
     )
   end
   let(:float) { nil }
-  let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -37,6 +37,12 @@ describe ArticleJSON::Export::FacebookInstantArticle::Elements::Image do
         '<figure class="float-right"><img src="/foo/bar.jpg">' \
           '<figcaption>Foo Bar</figcaption></figure>'
       end
+      it { should eq expected_html }
+    end
+
+    context 'when no caption is provided' do
+      let(:caption) { [] }
+      let(:expected_html) { '<figure><img src="/foo/bar.jpg"></figure>' }
       it { should eq expected_html }
     end
   end

--- a/spec/article_json/export/facebook_instant_article/elements/quote_spec.rb
+++ b/spec/article_json/export/facebook_instant_article/elements/quote_spec.rb
@@ -8,10 +8,12 @@ describe ArticleJSON::Export::FacebookInstantArticle::Elements::Quote do
           content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
         ),
       ],
-      caption: [ArticleJSON::Elements::Text.new(content: 'Baz')],
+      caption: caption,
       float: float
     )
   end
+  let(:float) { nil }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Baz')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -38,6 +40,11 @@ describe ArticleJSON::Export::FacebookInstantArticle::Elements::Quote do
         '<aside><p>Foo Bar</p><cite>Baz</cite></aside>'
       end
       it { should eq expected_html }
+    end
+
+    context 'when no caption is present' do
+      let(:caption) { [] }
+      it { should eq '<aside><p>Foo Bar</p></aside>' }
     end
   end
 end

--- a/spec/article_json/export/html/elements/embed_spec.rb
+++ b/spec/article_json/export/html/elements/embed_spec.rb
@@ -6,24 +6,36 @@ describe ArticleJSON::Export::HTML::Elements::Embed do
     ArticleJSON::Elements::Embed.new(
       embed_type: embed_type,
       embed_id: 666,
-      caption: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')],
+      caption: caption,
       tags: %w(test)
     )
   end
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
+    let(:oembed_data) { { html: 'Embedded Object: something-666' } }
+    before do
+      allow(source_element).to receive(:oembed_data).and_return(oembed_data)
+    end
 
     context 'when the endpoint successfully returns OEmbed data' do
-      let(:expected_html) do
-        '<figure><div class="embed">Embedded Object: something-666</div>' \
+      context 'with a proper caption' do
+        let(:expected_html) do
+          '<figure><div class="embed">Embedded Object: something-666</div>' \
           '<figcaption>Foo Bar</figcaption></figure>'
+        end
+        it { should eq expected_html }
       end
-      let(:oembed_data) { { html: 'Embedded Object: something-666' } }
-      before do
-        allow(source_element).to receive(:oembed_data).and_return(oembed_data)
+
+      context 'without a proper caption' do
+        let(:caption) { [] }
+        let(:expected_html) do
+          '<figure><div class="embed">Embedded Object: something-666</div>' \
+          '</figure>'
+        end
+        it { should eq expected_html }
       end
-      it { should eq expected_html }
     end
 
     context 'when the endpoint does not return OEmbed data' do
@@ -34,10 +46,7 @@ describe ArticleJSON::Export::HTML::Elements::Embed do
         'https://www.youtube.com/watch?v=666</a> is not available.</span>'\
         '</div><figcaption>Foo Bar</figcaption></figure>'
       end
-      let(:oembed_data) { { html: 'Embedded Object: something-666' } }
-      before do
-        allow(source_element).to receive(:oembed_data).and_return(nil)
-      end
+      let(:oembed_data) { nil }
       it { should eq expected_html }
     end
   end

--- a/spec/article_json/export/html/elements/image_spec.rb
+++ b/spec/article_json/export/html/elements/image_spec.rb
@@ -4,12 +4,12 @@ describe ArticleJSON::Export::HTML::Elements::Image do
   let(:source_element) do
     ArticleJSON::Elements::Image.new(
       source_url: '/foo/bar.jpg',
-      caption: [caption],
+      caption: caption,
       float: float
     )
   end
   let(:float) { nil }
-  let(:caption) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
@@ -37,6 +37,12 @@ describe ArticleJSON::Export::HTML::Elements::Image do
         '<figure class="float-right"><img src="/foo/bar.jpg">' \
           '<figcaption>Foo Bar</figcaption></figure>'
       end
+      it { should eq expected_html }
+    end
+
+    context 'when no caption is provided' do
+      let(:caption) { [] }
+      let(:expected_html) { '<figure><img src="/foo/bar.jpg"></figure>' }
       it { should eq expected_html }
     end
   end

--- a/spec/article_json/export/html/elements/quote_spec.rb
+++ b/spec/article_json/export/html/elements/quote_spec.rb
@@ -8,16 +8,17 @@ describe ArticleJSON::Export::HTML::Elements::Quote do
           content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
         ),
       ],
-      caption: [ArticleJSON::Elements::Text.new(content: 'Baz')],
+      caption: caption,
       float: float
     )
   end
+  let(:float) { nil }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Baz')] }
 
   describe '#export' do
     subject { element.export.to_html(save_with: 0) }
 
     context 'when the quote is not floating' do
-      let(:float) { nil }
       let(:expected_html) do
         '<div class="quote"><p>Foo Bar</p><small>Baz</small></div>'
       end
@@ -38,6 +39,11 @@ describe ArticleJSON::Export::HTML::Elements::Quote do
         '<div class="quote float-right"><p>Foo Bar</p><small>Baz</small></div>'
       end
       it { should eq expected_html }
+    end
+
+    context 'when no caption is present' do
+      let(:caption) { [] }
+      it { should eq '<div class="quote"><p>Foo Bar</p></div>' }
     end
   end
 end

--- a/spec/article_json/import/google_doc/html/embed_parser_shared.rb
+++ b/spec/article_json/import/google_doc/html/embed_parser_shared.rb
@@ -2,11 +2,13 @@ shared_context 'for an embed parser' do
   subject(:parser) do
     described_class.new(
       node: Nokogiri::HTML.fragment(html.strip),
-      caption_node: Nokogiri::HTML.fragment('<p><span>Caption</span></p>'),
+      caption_node:
+        Nokogiri::HTML.fragment("<p><span>#{caption_text}</span></p>"),
       css_analyzer: ArticleJSON::Import::GoogleDoc::HTML::CSSAnalyzer.new
     )
   end
 
+  let(:caption_text) { 'Caption' }
   let(:url) { url_examples.sample }
   let(:html) do
     <<-html
@@ -47,8 +49,24 @@ shared_context 'for an embed parser' do
       expect(subject.embed_type).to eq expected_embed_type
       expect(subject.embed_id).to eq expected_embed_id
       expect(subject.tags).to match_array expected_tags
-      expect(subject.caption).to all be_a ArticleJSON::Elements::Text
-      expect(subject.caption.first.content).to eq 'Caption'
+      expect(subject.caption).to be_an Array
+    end
+
+    context 'when a caption is provided' do
+      it 'should have the right caption defined' do
+        expect(subject.caption).to be_an Array
+        expect(subject.caption).to all be_a ArticleJSON::Elements::Text
+        expect(subject.caption.first.content).to eq caption_text
+      end
+    end
+
+    context 'when the caption is `[no-caption]`' do
+      let(:caption_text) { '[no-caption]' }
+
+      it 'should have an empty list as caption' do
+        expect(subject.caption).to be_an Array
+        expect(subject.caption).to be_empty
+      end
     end
   end
 

--- a/spec/article_json/import/google_doc/html/embedded_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/embedded_parser_spec.rb
@@ -55,9 +55,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedParser do
       let(:caption_node) { nil }
       it 'returns a list with one empty text element' do
         expect(subject).to be_an Array
-        expect(subject.size).to eq 1
-        expect(subject).to all be_a ArticleJSON::Elements::Text
-        expect(subject.first.content).to eq '&nbsp;'
+        expect(subject).to be_empty
       end
     end
   end

--- a/spec/article_json/import/google_doc/html/image_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/image_parser_spec.rb
@@ -18,7 +18,8 @@ describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
   let(:css) { '' }
   let(:source_url) { 'foo/bar.jpg' }
   let(:image_fragment) { "<p><span><img src=\"#{source_url}\"></span></p>" }
-  let(:caption_fragment) { '<p><span>foo</span></p>' }
+  let(:caption_text) { 'foo' }
+  let(:caption_fragment) { "<p><span>#{caption_text}</span></p>" }
 
   describe '#source_url' do
     subject { element.source_url }
@@ -150,7 +151,15 @@ describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
 
     context 'when the caption nil' do
       let(:caption_node) { nil }
-      it 'returns a list with one empty text element' do
+      it 'returns an empty list' do
+        expect(subject).to be_an Array
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when the caption is `[no-caption]`' do
+      let(:caption_text) { '[no-caption]' }
+      it 'returns an empty list' do
         expect(subject).to be_an Array
         expect(subject).to be_empty
       end

--- a/spec/article_json/import/google_doc/html/image_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/image_parser_spec.rb
@@ -152,9 +152,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
       let(:caption_node) { nil }
       it 'returns a list with one empty text element' do
         expect(subject).to be_an Array
-        expect(subject.size).to eq 1
-        expect(subject).to all be_a ArticleJSON::Elements::Text
-        expect(subject.first.content).to eq '&nbsp;'
+        expect(subject).to be_empty
       end
     end
   end

--- a/spec/article_json/import/google_doc/html/quote_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/quote_parser_spec.rb
@@ -50,13 +50,23 @@ describe ArticleJSON::Import::GoogleDoc::HTML::QuoteParser do
   describe '#caption' do
     subject { parser.caption }
 
-    it 'returns a list of text elements' do
-      expect(subject).to be_an Array
-      expect(subject.size).to eq 1
+    context 'if there is a proper caption defined' do
+      it 'returns a list of text elements' do
+        expect(subject).to be_an Array
+        expect(subject.size).to eq 1
 
-      expect(subject).to all be_a ArticleJSON::Elements::Text
+        expect(subject).to all be_a ArticleJSON::Elements::Text
 
-      expect(subject.first.content).to eq caption
+        expect(subject.first.content).to eq caption
+      end
+    end
+
+    context 'if the caption is `[no-caption]`' do
+      let(:caption) { '[no-caption]' }
+      it 'returns an empty list' do
+        expect(subject).to be_an Array
+        expect(subject).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes, an author wants to include an image, a quote, tweet or other embedded object without having it succeeded with a caption. This is now supported by writing `[no-caption]` below the element. The generated JSON will contain `caption: []` on the element.

Therefore, also add exporter support for elements without caption for images, embeds, and quotes.  In this case, the exporter is now able to simply export the element without any caption tag.