### PR TITLE
Add a plain text exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support to exporters for `caption` elements that are an empty array
 - GDoc Importer: Support `[no-caption]` text, returns empty caption for element
 - Fix AMP export of Twitter tweets
+- Add a plain text exporter
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/README.md
+++ b/README.md
@@ -201,6 +201,22 @@ An example of
 the AMP HTML export for the parsed reference document can be found 
 [here](https://github.com/Devex/article_json/blob/master/spec/fixtures/reference_document_exported.amp.html).
 
+### Plain Text
+As the name suggests, this exporter generates a plain text version of the article.
+Rich text elements like images, embeds or even text boxes are not being rendered.
+
+The reference document rendered as plain text can be found
+[here](https://github.com/Devex/article_json/blob/master/spec/fixtures/reference_document_exported.txt).
+
+Usage:
+```ruby
+# Create your article instance as you normally do
+article = ArticleJSON::Article.from_hash(parsed_json)
+
+# Then simply call `#to_plain_text` on it
+article.to_plain_text 
+```
+
 ## Contributing
 - Fork this repository
 - Implement your feature or fix including Tests

--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -39,6 +39,19 @@ require_relative 'article_json/import/google_doc/html/embedded_slideshare_parser
 require_relative 'article_json/import/google_doc/html/embedded_tweet_parser'
 require_relative 'article_json/import/google_doc/html/parser'
 
+require_relative 'article_json/export/common/elements/base'
+
+require_relative 'article_json/export/plain_text/elements/base'
+require_relative 'article_json/export/plain_text/elements/text'
+require_relative 'article_json/export/plain_text/elements/heading'
+require_relative 'article_json/export/plain_text/elements/paragraph'
+require_relative 'article_json/export/plain_text/elements/list'
+require_relative 'article_json/export/plain_text/elements/image'
+require_relative 'article_json/export/plain_text/elements/text_box'
+require_relative 'article_json/export/plain_text/elements/quote'
+require_relative 'article_json/export/plain_text/elements/embed'
+require_relative 'article_json/export/plain_text/exporter'
+
 require_relative 'article_json/export/common/html/elements/shared/caption'
 require_relative 'article_json/export/common/html/elements/shared/float'
 require_relative 'article_json/export/common/html/elements/base'

--- a/lib/article_json/article.rb
+++ b/lib/article_json/article.rb
@@ -46,6 +46,18 @@ module ArticleJSON
       amp_exporter.html
     end
 
+    # Exporter instance for plain text
+    # @return [ArticleJSON::Export::PlainText::Exporter]
+    def plain_text_exporter
+      ArticleJSON::Export::PlainText::Exporter.new(@elements)
+    end
+
+    # Plain text export of the article
+    # @return [String]
+    def to_plain_text
+      plain_text_exporter.text
+    end
+
     # Distribute passed elements evenly throughout the article. All passed
     # elements need to have an exporter to be represented in the rendered
     # article.

--- a/lib/article_json/configuration.rb
+++ b/lib/article_json/configuration.rb
@@ -52,7 +52,7 @@ module ArticleJSON
     # @param [Symbol] exporter
     # @param [Hash[Symbol => Class]] type_class_mapping
     def register_element_exporters(exporter, type_class_mapping)
-      valid_exporters = %i(html amp facebook_instant_article)
+      valid_exporters = %i(html amp facebook_instant_article plain_text)
       unless valid_exporters.include?(exporter)
         raise ArgumentError, '`exporter` needs to be one of ' \
                              "#{valid_exporters} but is `#{exporter.inspect}`"

--- a/lib/article_json/export/common/elements/base.rb
+++ b/lib/article_json/export/common/elements/base.rb
@@ -1,0 +1,84 @@
+module ArticleJSON
+  module Export
+    module Common
+      module Elements
+        module Base
+          # Extend `base` class with `ClassMethods` upon inclusion
+          def self.included(base)
+            base.extend ClassMethods
+          end
+
+          # @param [ArticleJSON::Elements::Base] element
+          def initialize(element)
+            @element = element
+          end
+
+          # Export the given element. Dynamically looks up the right
+          # export-element-class, instantiates it and then calls the `#export`
+          # method.
+          # @return [Object]
+          def export
+            exporter.export unless exporter.nil?
+          end
+
+          private
+
+          # Get the right exporter class for the given element
+          # @return [ArticleJSON::Export::Common::Elements::Base]
+          def exporter
+            @exporter ||=
+              self.class.base_class? ? self.class.build(@element) : self
+          end
+
+          # Return the base class for the current element instance
+          # @return [ArticleJSON::Export::Common::Elements::Base]
+          def base_class
+            self.class.namespace::Base
+          end
+
+          module ClassMethods
+            # Instantiate the correct sub class for a given element
+            # @param [ArticleJSON::Elements::Base] element
+            # @return [ArticleJSON::Export::Common::Elements::Base]
+            def build(element)
+              klass = exporter_by_type(element.type)
+              klass.new(element) unless klass.nil?
+            end
+
+            # Look up the correct exporter class based on the element type
+            # @param [Symbol] type
+            # @return [ArticleJSON::Export::Common::Elements::Base]
+            def exporter_by_type(type)
+              key = type.to_sym
+              custom_class = ArticleJSON.configuration.element_exporter_for(
+                export_format, key
+              )
+              custom_class || default_exporter_mapping[key]
+            end
+
+            # Check if the current class is the base class a child class.
+            # Since this common module is in a different namespace, a simple
+            # `self == Base` check does not work.
+            # @return [Boolean]
+            def base_class?
+              self == namespace::Base
+            end
+
+            def default_exporter_mapping
+              {
+                text: namespace::Text,
+                paragraph: namespace::Paragraph,
+                heading: namespace::Heading,
+                list: namespace::List,
+                quote: namespace::Quote,
+                image: namespace::Image,
+                embed: namespace::Embed,
+                text_box: namespace::TextBox,
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/common/html/elements/base.rb
+++ b/lib/article_json/export/common/html/elements/base.rb
@@ -4,22 +4,9 @@ module ArticleJSON
       module HTML
         module Elements
           module Base
-            # Extend `base` class with `ClassMethods` upon inclusion
+            # Also include the generic base element concern
             def self.included(base)
-              base.extend ClassMethods
-            end
-
-            # @param [ArticleJSON::Elements::Base] element
-            def initialize(element)
-              @element = element
-            end
-
-            # Export a HTML node out of the given element
-            # Dynamically looks up the right export-element-class, instantiates it
-            # and then calls the #build method.
-            # @return [Nokogiri::XML::NodeSet]
-            def export
-              exporter.export unless exporter.nil?
+              base.include ArticleJSON::Export::Common::Elements::Base
             end
 
             private
@@ -46,61 +33,6 @@ module ArticleJSON
             def wrap_in_node_set(elements, document)
               Nokogiri::XML::NodeSet.new(document).tap do |node_set|
                 elements.each { |element| node_set.push(element) }
-              end
-            end
-
-            # Get the right exporter class for the given element
-            # @return [ArticleJSON::Export::Common::HTML::Elements::Base]
-            def exporter
-              @exporter ||=
-                self.class.base_class? ? self.class.build(@element) : self
-            end
-
-            # Return the base class for the current element instance
-            # @return [ArticleJSON::Export::Common::HTML::Elements::Base]
-            def base_class
-              self.class.namespace::Base
-            end
-
-            module ClassMethods
-              # Instantiate the correct sub class for a given element
-              # @param [ArticleJSON::Elements::Base] element
-              # @return [ArticleJSON::Export::Common::HTML::Elements::Base]
-              def build(element)
-                klass = exporter_by_type(element.type)
-                klass.new(element) unless klass.nil?
-              end
-
-              # Look up the correct exporter class based on the element type
-              # @param [Symbol] type
-              # @return [ArticleJSON::Export::Common::HTML::Elements::Base]
-              def exporter_by_type(type)
-                key = type.to_sym
-                custom_class = ArticleJSON.configuration.element_exporter_for(
-                  export_format, key
-                )
-                custom_class || default_exporter_mapping[key]
-              end
-
-              # Check if the current class is the base class a child class.
-              # Since this common module is in a different namespace, a simple
-              # `self == Base` check does not work.
-              # @return [Boolean]
-              def base_class?
-                self == namespace::Base
-              end
-
-              def default_exporter_mapping
-                {
-                  text: namespace::Text,
-                  paragraph: namespace::Paragraph,
-                  heading: namespace::Heading,
-                  list: namespace::List,
-                  quote: namespace::Quote,
-                  image: namespace::Image,
-                  embed: namespace::Embed,
-                  text_box: namespace::TextBox,
-                }
               end
             end
           end

--- a/lib/article_json/export/plain_text/elements/base.rb
+++ b/lib/article_json/export/plain_text/elements/base.rb
@@ -1,0 +1,53 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Base
+          include ArticleJSON::Export::Common::Elements::Base
+
+          # Export the given element. Dynamically looks up the right
+          # export-element-class, instantiates it and then calls the `#export`
+          # method.
+          # Defaults to an empty string, e.g. if no exporter is specified for
+          # the given type.
+          # @return [String]
+          def export
+            super || ''
+          end
+
+          class << self
+            # Return the module namespace this class and its subclasses are
+            # nested in
+            # @return [Module]
+            def namespace
+              ArticleJSON::Export::PlainText::Elements
+            end
+
+            private
+
+            # The format this exporter is returning. This is used to determine
+            # which custom element exporters should be applied from the
+            # configuration.
+            # @return [Symbol]
+            def export_format
+              :plain_text
+            end
+
+            def default_exporter_mapping
+              {
+                text: namespace::Text,
+                paragraph: namespace::Paragraph,
+                heading: namespace::Heading,
+                list: namespace::List,
+                quote: namespace::Quote,
+                image: nil,
+                embed: nil,
+                text_box: nil,
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/embed.rb
+++ b/lib/article_json/export/plain_text/elements/embed.rb
@@ -1,0 +1,16 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Embed < Base
+          # Embedded elements are being skipped when rendering plain text.
+          # Therefore, return an empty string.
+          # @return [String]
+          def export
+            ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/heading.rb
+++ b/lib/article_json/export/plain_text/elements/heading.rb
@@ -1,0 +1,27 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Heading < Base
+          # Headline separated by newlines
+          # @return [String]
+          def export
+            "#{leading_newlines}#{@element.content}\n\n"
+          end
+
+          private
+
+          # String with dynamic number of newlines, depending on heading level.
+          # @return [String]
+          def leading_newlines
+            case @element.level
+            when 1 then "\n\n\n"
+            when 2 then "\n\n"
+            else "\n"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/image.rb
+++ b/lib/article_json/export/plain_text/elements/image.rb
@@ -1,0 +1,16 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Image < Base
+          # Images are being skipped when rendering plain text. Therefore,
+          # return an empty string.
+          # @return [String]
+          def export
+            ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/list.rb
+++ b/lib/article_json/export/plain_text/elements/list.rb
@@ -1,0 +1,50 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class List < Base
+          # List of strings, one per line. If the list type is "ordered" then
+          # each line is preceded with a number, otherwise a dash. Newlines
+          # within a list item are indented accordingly.
+          # @return [String]
+          def export
+            "#{list}\n"
+          end
+
+          private
+
+          # Plain-text list of items using the right prefix
+          # @return [String]
+          def list
+            @element
+              .content
+              &.each_with_index
+              &.map do |content, index|
+                "#{prefix(index)} #{paragraph_exporter.new(content).export}"
+                  .gsub(/\n(?!$)/, newline_with_indention)
+              end&.join || ''
+          end
+
+          # Prefix used for every list item
+          # @param [String] index
+          def prefix(index)
+            @element.list_type == :ordered ? "#{index + 1}." : '-'
+          end
+
+          # Newline followed by the right amount of spaces to align with the
+          # indentation from the prefix
+          # @return [String]
+          def newline_with_indention
+            "\n " + ' ' * prefix(0).length
+          end
+
+          # Get the exporter class for paragraph elements
+          # @return [ArticleJSON::Export::Common::HTML::Elements::Base]
+          def paragraph_exporter
+            self.class.exporter_by_type(:paragraph)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/paragraph.rb
+++ b/lib/article_json/export/plain_text/elements/paragraph.rb
@@ -1,0 +1,33 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Paragraph < Base
+          # Plain text from the paragraph. Any formatting is disregarded.
+          # Followed by a newline.
+          # @return [String]
+          def export
+            "#{text}\n"
+          end
+
+          private
+
+          # Plain text of the paragraph
+          # @return [String]
+          def text
+            @element
+              .content
+              &.map { |text_element| text_exporter.new(text_element).export }
+              &.join
+          end
+
+          # Get the exporter class for text elements
+          # @return [ArticleJSON::Export::PlainText::Elements::Base]
+          def text_exporter
+            self.class.exporter_by_type(:text)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/quote.rb
+++ b/lib/article_json/export/plain_text/elements/quote.rb
@@ -1,0 +1,35 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Quote < Base
+          # Quotes are just rendered with a preceding blank line. If a caption
+          # is present, it is rendered below the quote indented with two dashes.
+          # @return [String]
+          def export
+            "\n#{quote_text}\n"
+          end
+
+          private
+
+          # Plain text representation of the entire quote
+          # @return [String]
+          def quote_text
+            extract_text(@element.content).tap do |text|
+              if @element.caption&.any?
+                text << " --#{extract_text(@element.caption)}\n"
+              end
+            end
+          end
+
+          # Extract plain text from given element
+          # @param [ArticleJSON::Elements::Base] elements
+          # @return [String]
+          def extract_text(elements)
+            elements.map { |text| base_class.new(text).export }.join
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/text.rb
+++ b/lib/article_json/export/plain_text/elements/text.rb
@@ -1,0 +1,16 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class Text < Base
+          # Text is just returned plain, no formatting or linking is taken into
+          # account.
+          # @return [String]
+          def export
+            @element.content
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/elements/text_box.rb
+++ b/lib/article_json/export/plain_text/elements/text_box.rb
@@ -1,0 +1,16 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      module Elements
+        class TextBox < Base
+          # Text boxes are being skipped when rendering plain text. Therefore,
+          # return an empty string.
+          # @return [String]
+          def export
+            ''
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/plain_text/exporter.rb
+++ b/lib/article_json/export/plain_text/exporter.rb
@@ -1,0 +1,23 @@
+module ArticleJSON
+  module Export
+    module PlainText
+      class Exporter
+        # @param [Array[ArticleJSON::Elements::Base]] elements
+        def initialize(elements)
+          @elements = elements
+        end
+
+        # Generate a string with the plain text representation of all elements
+        # @return [String]
+        def text
+          @text ||=
+            @elements.map do |element|
+              ArticleJSON::Export::PlainText::Elements::Base
+                .build(element)
+                &.export
+            end.join.strip
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/article_spec.rb
+++ b/spec/article_json/article_spec.rb
@@ -53,6 +53,17 @@ describe ArticleJSON::Article do
     it { should eq '<p>Foo Bar</p>' }
   end
 
+  describe '#plain_text_exporter' do
+    subject { article.plain_text_exporter }
+    it { should be_a ArticleJSON::Export::PlainText::Exporter }
+  end
+
+  describe '#to_plain_text' do
+    subject { article.to_plain_text }
+    it { should be_a String }
+    it { should eq 'Foo Bar' }
+  end
+
   describe '#place_additional_elements' do
     subject { article.place_additional_elements(additional_elements) }
     let(:paragraph) { ArticleJSON::Elements::Paragraph.new(content: 'text') }

--- a/spec/article_json/export/plain_text/elements/base_spec.rb
+++ b/spec/article_json/export/plain_text/elements/base_spec.rb
@@ -1,0 +1,188 @@
+describe ArticleJSON::Export::PlainText::Elements::Base do
+  subject(:element) { described_class.new(source_element) }
+
+  describe '#export' do
+    subject { element.export }
+
+    let(:sample_text) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+    let(:sample_paragraph) do
+      ArticleJSON::Elements::Paragraph.new(content: [sample_text])
+    end
+
+    context 'when the source element is a text' do
+      let(:source_element) { sample_text }
+      it { should eq 'Foo Bar' }
+    end
+
+    context 'when the source element is a heading' do
+      let(:source_element) do
+        ArticleJSON::Elements::Heading.new(content: 'Foo Bar', level: 1)
+      end
+      it { should eq "\n\n\nFoo Bar\n\n" }
+    end
+
+    context 'when the source element is a paragraph' do
+      let(:source_element) { sample_paragraph }
+      it { should eq "Foo Bar\n" }
+    end
+
+    context 'when the source element is a list' do
+      let(:source_element) do
+        ArticleJSON::Elements::List.new(content: [sample_paragraph])
+      end
+      it { should eq "- Foo Bar\n\n" }
+    end
+
+    context 'when the source element is a image' do
+      let(:source_element) do
+        ArticleJSON::Elements::Image.new(
+          source_url: '/foo/bar.jpg',
+          caption: [sample_text]
+        )
+      end
+      it { should eq '' }
+    end
+
+    context 'when the source element is a text box' do
+      let(:source_element) do
+        ArticleJSON::Elements::TextBox.new(content: [sample_paragraph])
+      end
+      it { should eq '' }
+    end
+
+    context 'when the source element is a quote' do
+      let(:source_element) do
+        ArticleJSON::Elements::Quote.new(
+          content: [sample_paragraph],
+          caption: [ArticleJSON::Elements::Text.new(content: 'Baz')]
+        )
+      end
+      let(:expected_text) do
+        "\nFoo Bar\n --Baz\n\n"
+      end
+      it { should eq expected_text }
+    end
+
+    context 'when the source element is an embedded element' do
+      let(:source_element) do
+        ArticleJSON::Elements::Embed.new(
+          embed_type: :something,
+          embed_id: 666,
+          caption: [sample_text]
+        )
+      end
+      it { should eq '' }
+    end
+  end
+
+  describe '.build' do
+    subject { described_class.build(element) }
+
+    context 'when the element type is text' do
+      let(:element) { ArticleJSON::Elements::Text.new(content: '') }
+      it { should be_a ArticleJSON::Export::PlainText::Elements::Text }
+    end
+
+    context 'when the element type is heading' do
+      let(:element) { ArticleJSON::Elements::Heading.new(content: 1, level: 1) }
+      it { should be_a ArticleJSON::Export::PlainText::Elements::Heading }
+    end
+
+    context 'when the element type is paragraph' do
+      let(:element) { ArticleJSON::Elements::Paragraph.new(content: []) }
+      it { should be_a ArticleJSON::Export::PlainText::Elements::Paragraph }
+    end
+
+    context 'when the element type is list' do
+      let(:element) { ArticleJSON::Elements::List.new(content: []) }
+      it { should be_a ArticleJSON::Export::PlainText::Elements::List }
+    end
+
+    context 'when the element type is image' do
+      let(:element) do
+        ArticleJSON::Elements::Image.new(source_url: '', caption: [])
+      end
+      it { should be nil }
+    end
+
+    context 'when the element type is text_box' do
+      let(:element) { ArticleJSON::Elements::TextBox.new(content: []) }
+      it { should be nil }
+    end
+
+    context 'when the element type is quote' do
+      let(:element) do
+        ArticleJSON::Elements::Quote.new(content: [], caption: [])
+      end
+      it { should be_a ArticleJSON::Export::PlainText::Elements::Quote }
+    end
+
+    context 'when the element type is embed' do
+      let(:element) do
+        ArticleJSON::Elements::Embed
+          .new(embed_type: '', embed_id: '', caption: [])
+      end
+      it { should be nil }
+    end
+  end
+
+  describe '.exporter_by_type' do
+    subject { described_class.exporter_by_type(element_type) }
+
+    context 'when the element type is text' do
+      let(:element_type) { :text }
+      it { should be ArticleJSON::Export::PlainText::Elements::Text }
+    end
+
+    context 'when the element type is heading' do
+      let(:element_type) { :heading }
+      it { should be ArticleJSON::Export::PlainText::Elements::Heading }
+    end
+
+    context 'when the element type is paragraph' do
+      let(:element_type) { :paragraph }
+      it { should be ArticleJSON::Export::PlainText::Elements::Paragraph }
+    end
+
+    context 'when the element type is list' do
+      let(:element_type) { :list }
+      it { should be ArticleJSON::Export::PlainText::Elements::List }
+    end
+
+    context 'when the element type is image' do
+      let(:element_type) { :image }
+      it { should be nil }
+    end
+
+    context 'when the element type is text_box' do
+      let(:element_type) { :text_box }
+      it { should be nil }
+    end
+
+    context 'when the element type is quote' do
+      let(:element_type) { :quote }
+      it { should be ArticleJSON::Export::PlainText::Elements::Quote }
+    end
+
+    context 'when the element type is embed' do
+      let(:element_type) { :embed }
+      it { should be nil }
+    end
+
+    context 'when the element was additionally registered' do
+      before do
+        ArticleJSON.configure do |c|
+          c.register_element_exporters(:plain_text, foo: Object)
+        end
+      end
+      let(:element_type) { :foo }
+      it { should be Object }
+    end
+  end
+
+  describe '.namespace' do
+    subject { described_class.namespace }
+    it { should be_a Module }
+    it { should eq ArticleJSON::Export::PlainText::Elements }
+  end
+end

--- a/spec/article_json/export/plain_text/elements/embed_spec.rb
+++ b/spec/article_json/export/plain_text/elements/embed_spec.rb
@@ -1,0 +1,36 @@
+describe ArticleJSON::Export::PlainText::Elements::Embed do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:embed_type) { :something }
+  let(:source_element) do
+    ArticleJSON::Elements::Embed.new(
+      embed_type: embed_type,
+      embed_id: 666,
+      caption: caption,
+      tags: %w(test)
+    )
+  end
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
+
+  describe '#export' do
+    subject { element.export }
+    let(:oembed_data) { { html: 'Embedded Object: something-666' } }
+
+    context 'when the endpoint successfully returns OEmbed data' do
+      context 'with a proper caption' do
+        it { should eq '' }
+      end
+
+      context 'without a proper caption' do
+        let(:caption) { [] }
+        it { should eq '' }
+      end
+    end
+
+    context 'when the endpoint does not return OEmbed data' do
+      let(:embed_type) { :youtube_video }
+      let(:oembed_data) { nil }
+      it { should eq '' }
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/elements/heading_spec.rb
+++ b/spec/article_json/export/plain_text/elements/heading_spec.rb
@@ -1,0 +1,28 @@
+describe ArticleJSON::Export::PlainText::Elements::Heading do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Heading.new(content: 'Foo Bar', level: level)
+  end
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the heading level is 1' do
+      let(:level) { 1 }
+      it { should eq "\n\n\nFoo Bar\n\n" }
+    end
+
+    context 'when the heading level is 2' do
+      let(:level) { 2 }
+      it { should eq "\n\nFoo Bar\n\n" }
+    end
+
+    (3..6).each do |i|
+      context "when the heading level is #{i}" do
+        let(:level) { i }
+        it { should eq "\nFoo Bar\n\n" }
+      end
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/elements/image_spec.rb
+++ b/spec/article_json/export/plain_text/elements/image_spec.rb
@@ -1,0 +1,37 @@
+describe ArticleJSON::Export::PlainText::Elements::Image do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Image.new(
+      source_url: '/foo/bar.jpg',
+      caption: caption,
+      float: float
+    )
+  end
+  let(:float) { nil }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the image is not floating' do
+      it { should eq '' }
+    end
+
+    context 'when the image is floating on the left' do
+      let(:float) { :left }
+      it { should eq '' }
+    end
+
+    context 'when the image is floating on the right' do
+      let(:float) { :right }
+      it { should eq '' }
+    end
+
+    context 'when no caption is provided' do
+      let(:caption) { [] }
+      let(:expected_text) { '<figure><img src="/foo/bar.jpg"></figure>' }
+      it { should eq '' }
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/elements/list_spec.rb
+++ b/spec/article_json/export/plain_text/elements/list_spec.rb
@@ -1,0 +1,38 @@
+describe ArticleJSON::Export::PlainText::Elements::List do
+
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::List.new(
+      content: [
+        content_factory.call('Foo'),
+        content_factory.call("Bar\nBar"),
+        content_factory.call('Baz'),
+      ],
+      list_type: list_type
+    )
+  end
+  let(:content_factory) do
+    ->(text) do
+      ArticleJSON::Elements::Paragraph.new(
+        content: [
+          ArticleJSON::Elements::Text.new(content: text)
+        ]
+      )
+    end
+  end
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when it is an ordered list' do
+      let(:list_type) { :ordered }
+      it { should eq "1. Foo\n2. Bar\n   Bar\n3. Baz\n\n" }
+    end
+
+    context 'when it is an unordered list' do
+      let(:list_type) { :unordered }
+      it { should eq "- Foo\n- Bar\n  Bar\n- Baz\n\n" }
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/elements/paragraph_spec.rb
+++ b/spec/article_json/export/plain_text/elements/paragraph_spec.rb
@@ -1,0 +1,18 @@
+describe ArticleJSON::Export::PlainText::Elements::Paragraph do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Paragraph.new(content: [content_1, content_2])
+  end
+  let(:content_1) do
+    ArticleJSON::Elements::Text.new(content: 'Check this out: ', bold: true)
+  end
+  let(:content_2) do
+    ArticleJSON::Elements::Text.new(content: 'Foo Bar', href: '/foo/bar')
+  end
+
+  describe '#export' do
+    subject { element.export }
+    it { should eq "Check this out: Foo Bar\n" }
+  end
+end

--- a/spec/article_json/export/plain_text/elements/quote_spec.rb
+++ b/spec/article_json/export/plain_text/elements/quote_spec.rb
@@ -1,0 +1,40 @@
+describe ArticleJSON::Export::PlainText::Elements::Quote do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Quote.new(
+      content: [
+        ArticleJSON::Elements::Paragraph.new(
+          content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
+        ),
+      ],
+      caption: caption,
+      float: float
+    )
+  end
+  let(:float) { nil }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Baz')] }
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the quote is not floating' do
+      it { should eq "\nFoo Bar\n --Baz\n\n" }
+    end
+
+    context 'when the quote is floating on the left' do
+      let(:float) { :left }
+      it { should eq "\nFoo Bar\n --Baz\n\n" }
+    end
+
+    context 'when the quote is floating on the right' do
+      let(:float) { :right }
+      it { should eq "\nFoo Bar\n --Baz\n\n" }
+    end
+
+    context 'when no caption is present' do
+      let(:caption) { [] }
+      it { should eq "\nFoo Bar\n\n" }
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/elements/text_box_spec.rb
+++ b/spec/article_json/export/plain_text/elements/text_box_spec.rb
@@ -1,0 +1,33 @@
+describe ArticleJSON::Export::PlainText::Elements::TextBox do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::TextBox.new(
+      content: [
+        ArticleJSON::Elements::Paragraph.new(
+          content: [ArticleJSON::Elements::Text.new(content: 'Foo Bar')]
+        ),
+      ],
+      float: float
+    )
+  end
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the box is not floating' do
+      let(:float) { nil }
+      it { should eq '' }
+    end
+
+    context 'when the box is floating left' do
+      let(:float) { :left }
+      it { should eq '' }
+    end
+
+    context 'when the box is floating right' do
+      let(:float) { :right }
+      it { should eq '' }
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/elements/text_spec.rb
+++ b/spec/article_json/export/plain_text/elements/text_spec.rb
@@ -1,0 +1,70 @@
+describe ArticleJSON::Export::PlainText::Elements::Text do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Text.new(
+      content: content,
+      bold: bold,
+      italic: italic,
+      href: href
+    )
+  end
+  let(:content) { 'Foo Bar' }
+  let(:bold) { false }
+  let(:italic) { false }
+  let(:href) { nil }
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the source element is plain text' do
+      it { should eq content }
+    end
+
+    context 'when the source element contains a newline character' do
+      let(:content) { "Foo\nBar" }
+      it { should eq content }
+    end
+
+    context 'when the source element is bold text' do
+      let(:bold) { true }
+      it { should eq content }
+    end
+
+    context 'when the source element is italic text' do
+      let(:italic) { true }
+      it { should eq content }
+    end
+
+    context 'when the source element is italic and bold text' do
+      let(:bold) { true }
+      let(:italic) { true }
+      it { should eq content }
+    end
+
+    context 'when the source element is a link' do
+      let(:href) { '/foo/bar' }
+      let(:expected_link) { '<a href="/foo/bar">Foo Bar</a>' }
+
+      context 'with plain text' do
+        it { should eq content }
+      end
+
+      context 'with bold text' do
+        let(:bold) { true }
+        it { should eq content }
+      end
+
+      context 'with italic text' do
+        let(:italic) { true }
+        it { should eq content }
+      end
+
+      context 'with italic and bold text' do
+        let(:bold) { true }
+        let(:italic) { true }
+        it { should eq content }
+      end
+    end
+  end
+end

--- a/spec/article_json/export/plain_text/exporter_spec.rb
+++ b/spec/article_json/export/plain_text/exporter_spec.rb
@@ -1,0 +1,12 @@
+describe ArticleJSON::Export::PlainText::Exporter do
+  subject(:exporter) { described_class.new(elements) }
+
+  describe 'reference document test' do
+    subject { exporter.text }
+    let(:text) { File.read('spec/fixtures/reference_document_exported.txt') }
+    let(:json) { File.read('spec/fixtures/reference_document_parsed.json') }
+    let(:elements) { ArticleJSON::Article.from_json(json).elements }
+    before { stub_oembed_requests }
+    it { should eq text.strip }
+  end
+end

--- a/spec/fixtures/reference_document_exported.txt
+++ b/spec/fixtures/reference_document_exported.txt
@@ -1,0 +1,102 @@
+The main content of the article starts here.
+
+
+Headings
+
+Internal headings need to be in the formatting “Heading x”, just pick it from the toolbar above.
+Note that horizontal lines will not show up in the converted article format but are used to terminate certain sections like quotes or text boxes. More one this later on...
+
+
+Basic Text and a Link
+
+Text can include links and basic formatting. By using the toolbar you can define bold and italic text.
+To create a link just use the button within the toolbar: Lorem ipsum
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+Lists
+
+There is support for both ordered and unordered lists, just just the respective button from the toolbar and get started.
+- This is an unordered list...
+- … with two entries
+
+1. And here we have a numbered list
+2. This time, with three entries.
+3. Great, isn’t it?!
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+Images
+
+Images can be inserted by using the insert image function of Google Docs. It allows you to upload any image from your computer or specify a URL.
+When an image is smaller than the medium width of the document, it will be displayed as a small image with text floating around it.
+The following paragraph is then normal content again. By aligning small images to the right they will later on be displayed on the right side of the article. Let’s first add some lorem ipsum text to flow around these small images.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Large images that are supposed to take up the full width within the the article format are also big ones within the Google Document.
+
+
+
+Embedded Elements
+
+Different types of multimedia elements can be embedded in this document. It is enough to provide the URL of the element you want to embed. Embeddings can be tagged as well, just provide a space-separated list of tags in brackets, after the URL - we’ll see some examples further down.
+
+
+Videos: Vimeo
+
+Videos are just referenced by the URL. It doesn’t matter if the URL is a hyperlink or just normal text. The important thing is that it has its own paragraph with nothing else in it. The alignment (centered  in this example) doesn’t really matter.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+Videos: YouTube
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+Videos: Facebook
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+Slideshows
+
+Slideshows are, like videos, referenced by an URL:
+Please note that currently only slideshows on slideshare are recognized.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+Twitter Tweets
+
+Individual tweets can be embedded by providing the URL:
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+
+Quotes
+
+A subtitle named “Quote:” indicates the start of a quote which continues until the first occurring horizontal line. The last paragraph is formatted to be the quoted source. Quotes can be aligned to the left, right or center. Centered quotes will span the whole width of the article while left- and right-aligned are smaller and have text floating around it.
+
+Operator! Give me the number for 911!
+ --Homer Simpson
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Marge, don't discourage the boy! Weaseling out of things is important to learn. It's what separates us from the animals! Except the weasel.
+ --Homer Simpson
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Oh, so they have internet on computers now!
+ --Homer Simpson
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+
+
+Text Boxes
+
+Text boxes include internal excerpts from the article (Story Highlights) or additional information related to the article and are displayed either on the left or on the right. A subtitle named “Textbox:” indicates the start of a text box which continues until the first occurring horizontal line. Text boxes can contain headers which have to be in the formatting “Heading 2”.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+To make the text box appear on the right side of the article just align it’s text to the right.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
As the name suggests, this exporter generates a plain text version of the article. Rich text elements like images, embeds or even text boxes are not being rendered.

For this, extract the reusable part of the `Base` concern and implement the element exporters for this format. There are no exporters for the skipped items. But via the custom exporter API it is easy to add them, if they should be required for some consumers.