### PR TITLE
Improve support of multiple calls to `Article#place_additional_elements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - GDoc Importer: Support `[no-caption]` text, returns empty caption for element
 - Fix AMP export of Twitter tweets
 - Add a plain text exporter
+- Improve behavior of multiple calls to `Article#place_additional_elements`
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/lib/article_json/utils/additional_element_placer.rb
+++ b/lib/article_json/utils/additional_element_placer.rb
@@ -6,10 +6,10 @@ module ArticleJSON
     # there are not enough spaces, the remaining additional elements will be
     # appended to the existing article elements.
     class AdditionalElementPlacer
-      # @param [ArticleJSON::Article] article
+      # @param [Array[ArticleJSON::Article::Elements::Base]] elements
       # @param [Array[Object]] additional_elements
-      def initialize(article, additional_elements)
-        @elements = article.elements.dup
+      def initialize(elements, additional_elements)
+        @elements = elements.dup
         @additional_elements = additional_elements
       end
 

--- a/spec/article_json/utils/additional_element_placer_spec.rb
+++ b/spec/article_json/utils/additional_element_placer_spec.rb
@@ -1,18 +1,21 @@
 describe ArticleJSON::Utils::AdditionalElementPlacer do
   describe '#merge_elements' do
-    subject { described_class.new(article, additional_elements).merge_elements }
-    let(:paragraph) { ArticleJSON::Elements::Paragraph.new(content: 'text') }
+    subject do
+      described_class.new(article_elements, additional_elements).merge_elements
+    end
+    let(:text) { ArticleJSON::Elements::Text.new(content: 'Lorem Ipsum ') }
+    let(:paragraph) { ArticleJSON::Elements::Paragraph.new(content: [text]) }
     let(:image) do
-      ArticleJSON::Elements::Image.new(source_url: 'url', caption: 'caption')
+      ArticleJSON::Elements::Image.new(source_url: 'url', caption: [text])
     end
     let(:quote) do
-      ArticleJSON::Elements::Quote.new(content: 'uh la la', caption: 'caption')
+      ArticleJSON::Elements::Quote.new(content: [paragraph], caption: [text])
     end
-    let(:list) { ArticleJSON::Elements::List.new(content: '1 2 3') }
+    let(:list) { ArticleJSON::Elements::List.new(content: [paragraph]) }
     let(:embed) do
       ArticleJSON::Elements::Embed.new(embed_type: 'youtube',
                                        embed_id: 'qwe123',
-                                       caption: 'oh so funny')
+                                       caption: [text])
     end
 
     let(:article_elements) do
@@ -39,7 +42,6 @@ describe ArticleJSON::Utils::AdditionalElementPlacer do
         embed,
       ]
     end
-    let(:article) { ArticleJSON::Article.new(article_elements) }
 
     shared_examples 'for properly added additional elements' do
       it 'should place the elements in the right position' do


### PR DESCRIPTION
When calling `ArticleJSON::Article#place_additional_elements` multiple times with additional elements, they were previously directly placed into the article. This led to additional elements being placed very close together, since the second iteration did not know that there was already an additional element inserted earlier.

Now, the class keeps track of what additional elements are to be placed into the article, but only when accessing the `Article#elements` they are actually injected into the article. If more additional elements are added, the structure will be recalculated to guarantee an even distribution of the additional elements.