### PR TITLE
Remove deprecated HTML configuration methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix AMP export of Twitter tweets
 - Add a plain text exporter
 - Improve behavior of multiple calls to `Article#place_additional_elements`
+- Remove deprecated `#register_html_element_exporter`, use `#register_element_exporters` instead
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/lib/article_json/configuration.rb
+++ b/lib/article_json/configuration.rb
@@ -21,34 +21,12 @@ module ArticleJSON
       @custom_element_exporters = {}
     end
 
-    # Register a new HTML element exporter or overwrite existing ones.
-    # @param [Symbol] type
-    # @param [Class] klass
-    # @deprecated Use `#register_element_exporters_for(:html, ...)` instead
-    def register_html_element_exporter(type, klass)
-      register_element_exporters(:html, type => klass)
-    end
-
-    # Return custom HTML exporters
-    # @return [Hash[Symbol => Class]]
-    # @deprecated use `#exporter_for` instead
-    def html_element_exporters
-      @custom_element_exporters[:html] || {}
-    end
-
-    # Set custom HTML exporters
-    # @param [Hash[Symbol => Class]] value
-    # @deprecated use `#register_element_exporters(:html, ...)` instead
-    def html_element_exporters=(value)
-      @custom_element_exporters[:html] = value
-    end
-
     # Register new element exporters or overwrite existing ones for a given
     # exporter type.
     # Usage example:
     #  register_element_exporters(:html,
-    #                                 image: MyImageExporter,
-    #                                 advertisement: MyAdExporter)
+    #                             image: MyImageExporter,
+    #                             advertisement: MyAdExporter)
     # @param [Symbol] exporter
     # @param [Hash[Symbol => Class]] type_class_mapping
     def register_element_exporters(exporter, type_class_mapping)

--- a/spec/article_json/configuration_spec.rb
+++ b/spec/article_json/configuration_spec.rb
@@ -17,33 +17,7 @@ describe ArticleJSON::Configuration do
     end
   end
 
-  describe '#register_html_element_exporter' do
-    subject do
-      ArticleJSON.configure do |c|
-        c.register_html_element_exporter(:foo, Object)
-      end
-    end
-
-    context 'when there is no exporter registered' do
-      it 'registers an additional exporter' do
-        expect { subject }.to(
-          change { ArticleJSON.configuration.html_element_exporters }
-            .from({})
-            .to({ foo: Object })
-        )
-      end
-    end
-
-    context 'when there is already an exporter registered' do
-      before { configuration.html_element_exporters = { foo: Object } }
-      it 'registers an additional exporter' do
-        expect { subject }
-          .to_not change { ArticleJSON.configuration.html_element_exporters }
-      end
-    end
-  end
-
-  describe '#register_element_exporters_for' do
+  describe '#register_element_exporters' do
     subject do
       ArticleJSON.configure do |c|
         c.register_element_exporters(exporter, mapping)
@@ -114,16 +88,40 @@ describe ArticleJSON::Configuration do
     end
   end
 
-  describe '#html_element_exporters' do
-    subject { configuration.html_element_exporters }
+  describe '#element_exporter_for' do
+    subject { configuration.element_exporter_for(exporter_type, element_type) }
+    let(:exporter_type) { :my_exporter }
+    let(:element_type) { :my_element }
+    let(:custom_exporters) { {} }
 
-    context 'when not initialized' do
-      it { should eq({}) }
+    before do
+      configuration.instance_variable_set(:@custom_element_exporters,
+                                          custom_exporters)
+    end
+
+    context 'when the exporter type is not initialized' do
+      it { should be nil }
+    end
+
+    context 'when the exporter type is initialized' do
+      let(:custom_exporters_for_type) { {} }
+      let(:custom_exporters) { { exporter_type => custom_exporters_for_type } }
+
+      context 'but there is no exporter for the element type' do
+        it { should be nil }
+      end
+
+      context 'and there is an exporter for the element type' do
+        let(:custom_exporter_for_element) { double('custom_exporter') }
+        let(:custom_exporters_for_type) do
+          { element_type => custom_exporter_for_element }
+        end
+        it { should eq custom_exporter_for_element }
+      end
     end
 
     context 'when it has a value' do
-      before { configuration.html_element_exporters = { foo: 'bar' } }
-      it { should eq({ foo: 'bar' }) }
+
     end
   end
 end

--- a/spec/article_json/export/html/elements/base_spec.rb
+++ b/spec/article_json/export/html/elements/base_spec.rb
@@ -184,7 +184,7 @@ describe ArticleJSON::Export::HTML::Elements::Base do
     context 'when the element was additionally registered' do
       before do
         ArticleJSON.configure do |c|
-          c.register_html_element_exporter(:foo, Object)
+          c.register_element_exporters(:html, foo: Object)
         end
       end
       let(:element_type) { :foo }


### PR DESCRIPTION
These methods have been removed in favor of:
- `Configuration#register_element_exporters` and
- `Configuration#element_exporter_for`

[This is the PR that added the new methods and deprecated the old ones](https://github.com/Devex/article_json/pull/98)