### PR TITLE
Rework algorithm to place additional elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a plain text exporter
 - Improve behavior of multiple calls to `Article#place_additional_elements`
 - Remove deprecated `#register_html_element_exporter`, use `#register_element_exporters` instead
+- Rework algorithm to place additional elements to support better placement
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/lib/article_json/elements/paragraph.rb
+++ b/lib/article_json/elements/paragraph.rb
@@ -32,6 +32,16 @@ module ArticleJSON
         end
       end
 
+      # Return the sum of all characters within the content's text elements
+      # @return [Integer]
+      def length
+        return 0 if empty?
+        @content.reduce(0) do |sum, element|
+          sum + (element.respond_to?(:length) ? element.length : 0)
+        end
+      end
+      alias size length
+
       class << self
         # Create a paragraph element from Hash
         # @return [ArticleJSON::Elements::Paragraph]

--- a/lib/article_json/elements/text.rb
+++ b/lib/article_json/elements/text.rb
@@ -40,6 +40,14 @@ module ArticleJSON
         empty? || content.gsub(/[\s\u00A0]/, '').empty?
       end
 
+      # Get the number of characters contained by this text element
+      # @return [Integer]
+      def length
+        return 0 if blank?
+        content.length
+      end
+      alias size length
+
       class << self
         # Create a text element from Hash
         # @return [ArticleJSON::Elements::Text]

--- a/lib/article_json/utils/additional_element_placer.rb
+++ b/lib/article_json/utils/additional_element_placer.rb
@@ -2,9 +2,10 @@ module ArticleJSON
   module Utils
     # This class allows the user to place additional elements within an article.
     # It distributes elements over the whole article and ensures that an
-    # additional element is only ever placed between two paragraph elements. If
-    # there are not enough spaces, the remaining additional elements will be
-    # appended to the existing article elements.
+    # additional element is only ever placed between two paragraph elements or
+    # after a paragraph and before the next headline. If there are not enough
+    # spaces, the remaining additional elements will be appended to the existing
+    # article elements.
     class AdditionalElementPlacer
       # @param [Array[ArticleJSON::Article::Elements::Base]] elements
       # @param [Array[Object]] additional_elements
@@ -14,52 +15,78 @@ module ArticleJSON
       end
 
       # Distribute additional elements evenly throughout the article elements
+      #
+      # Outline of the algorithm:
+      # 1. It calculates every how many characters (only considering paragraphs)
+      #    an additional element should be inserted, given the number of
+      #    additional elements provided
+      # 2. It then iterates over the existing elements within the article,
+      #    inserting them into the resulting, merged article
+      # 3. As soon as it has passed the right amount characters, it checks if
+      #    the current position is eligible for inserting an additional element
+      #    (the previous element needs to be a paragraph and the following needs
+      #    to be either a paragraph or a headline)
+      #     a) If so, it inserts the additional element and recalculates in how
+      #        many characters the next element should be inserted, based on the
+      #        remaining number of characters and remaining additional elements
+      #     b) If not, it keeps iterating over the article until it finds an
+      #        eligible position and only then inserts the additional element
+      #        and recalculates the number of characters until the next
+      #        insertion
+      # 4. If there are still additional elements remaining which couldn't be
+      #    inserted (due to not finding enough eligible positions), they are
+      #    appended to the end of the article
+      #
       # @return [Array[ArticleJSON::Elements::Base|Object]]
       def merge_elements
-        indexes = indexes_for_additional_elements
-
-        if indexes.count < @additional_elements.count
-          @elements.push(*@additional_elements[indexes.count..-1])
-        end
-
-        indexes
-          .reverse
-          .zip(@additional_elements[0...indexes.count].reverse)
-          .each { |index, element| @elements.insert(index, element) }
-
+        remaining_elements = @additional_elements.dup
+        next_in = insert_next_element_in(0, remaining_elements)
+        characters_passed = 0
         @elements
+          .each_cons(2)
+          .each_with_object([]) do |(element, next_element), result|
+            result << element
+            characters_passed += element.length if element.respond_to?(:length)
+            next_in -= element.length if element.respond_to?(:length)
+            if insert_here?(next_in, element, next_element)
+              result << remaining_elements.shift
+              next_in = insert_next_element_in(characters_passed,
+                                               remaining_elements)
+            end
+          end
+          .push(@elements.last,      # add last element
+                *remaining_elements) # followed by remaining ads
       end
 
       private
 
-      # Find indexes within article elements where there is a paragraph on the
-      # current and on the next node
-      # @return [Array[Integer]]
-      def indexes_between_paragraphs
-        @elements
-          .each_cons(2) # iterate over elements in consecutive sets of 2
-          .with_index
-          .each_with_object([]) do |((current, following), index), possibilities|
-          if current.type == :paragraph && following.type == :paragraph
-            possibilities << index + 1
-          end
+      # Calculate in how many characters the next additional element should be
+      # inserted
+      # @param [Integer] characters_passed
+      # @param [Array] left_elements
+      # @return [Integer]
+      def insert_next_element_in(characters_passed, left_elements)
+        (total_length - characters_passed) / (left_elements.size + 1)
+      end
+
+      # Return the total length of the given elements
+      # @return [Integer]
+      def total_length
+        @total_length ||= @elements.reduce(0) do |sum, element|
+          sum + (element.respond_to?(:length) ? element.length : 0)
         end
       end
 
-      # Return evenly spread indexes of positions to insert a given number of
-      # additional elements
-      # @return [Array[Integer]]
-      def indexes_for_additional_elements
-        indexes = indexes_between_paragraphs
-        insert_every = indexes.count / @additional_elements.count
-
-        # in case there are more elements to add than available positions:
-        insert_every = 1 if insert_every == 0
-
-        indexes
-          .reject
-          .with_index { |_, index| (index + 1) % insert_every != 0 }
-          .take(@additional_elements.count)
+      # Check if the given position is eligible for inserting an additional
+      # element
+      # @param [Integer] next_in
+      # @param [ArticleJSON::Elements::Base] element
+      # @param [ArticleJSON::Elements::Base] next_element
+      # @return [Boolean]
+      def insert_here?(next_in, element, next_element)
+        next_in <= 0 &&
+          element.type == :paragraph &&
+          %i(paragraph heading).include?(next_element.type)
       end
     end
   end

--- a/spec/article_json/elements/paragraph_spec.rb
+++ b/spec/article_json/elements/paragraph_spec.rb
@@ -88,6 +88,49 @@ describe ArticleJSON::Elements::Paragraph do
     end
   end
 
+  describe '#length' do
+    subject { element.length }
+
+    context 'when `content` contains only text elements' do
+      context 'when some text elements contain actual text' do
+        let(:content) do
+          [
+            ArticleJSON::Elements::Text.new(content: ''),
+            ArticleJSON::Elements::Text.new(content: 'Lorem ipsum'),
+            ArticleJSON::Elements::Text.new(content: ' sit dol'),
+            ArticleJSON::Elements::Text.new(content: 'or'),
+          ]
+        end
+        it { should eq 21 }
+      end
+
+      context 'when all text elements are blank' do
+        let(:content) do
+          [
+            ArticleJSON::Elements::Text.new(content: ''),
+            ArticleJSON::Elements::Text.new(content: ' '),
+          ]
+        end
+        it { should eq 0 }
+      end
+    end
+
+    context 'when `content` contains other elements' do
+      let(:content) do
+        [
+          ArticleJSON::Elements::Image.new(source_url: 'foo.jpg', caption: []),
+          ArticleJSON::Elements::Text.new(content: 'Lorem ipsum'),
+        ]
+      end
+      it { should eq 11}
+    end
+
+    context 'when `content` is `nil`' do
+      let(:content) { nil }
+      it { should eq 0 }
+    end
+  end
+
   describe '.parse_hash' do
     subject { described_class.parse_hash(hash) }
     it { should be_a ArticleJSON::Elements::Paragraph }

--- a/spec/article_json/elements/text_spec.rb
+++ b/spec/article_json/elements/text_spec.rb
@@ -58,6 +58,25 @@ describe ArticleJSON::Elements::Text do
     end
   end
 
+  describe '#length' do
+    subject { element.length }
+
+    context 'when `content` contains text' do
+      let(:content) { 'Three little words' }
+      it { should eq 18 }
+    end
+
+    context 'when `content` is an empty String' do
+      let(:content) { '' }
+      it { should eq 0 }
+    end
+
+    context 'when `content` is `nil`' do
+      let(:content) { nil }
+      it { should eq 0 }
+    end
+  end
+
   describe '.parse_hash' do
     subject { described_class.parse_hash(hash) }
     it { should be_a ArticleJSON::Elements::Text }

--- a/spec/article_json/utils/additional_element_placer_spec.rb
+++ b/spec/article_json/utils/additional_element_placer_spec.rb
@@ -49,40 +49,6 @@ describe ArticleJSON::Utils::AdditionalElementPlacer do
       end
     end
 
-    context 'if the article has enough possible positions' do
-      let(:element_1) { double('additional_element_1', type: :element_1) }
-      let(:element_2) { double('additional_element_2', type: :element_2) }
-      let(:element_3) { double('additional_element_3', type: :element_3) }
-      let(:additional_elements) { [element_1, element_2, element_3] }
-
-      include_examples 'for properly added additional elements' do
-        let(:expected_article_elements) do
-          [
-            paragraph,
-            image,
-            image,
-            paragraph,
-            # Possible additional element position
-            paragraph,
-            element_1, # inserted element
-            paragraph,
-            # Possible additional element position
-            paragraph,
-            element_2, # inserted element
-            paragraph,
-            # Possible additional element position
-            paragraph,
-            quote,
-            quote,
-            paragraph,
-            element_3, # inserted element
-            paragraph,
-            embed,
-          ]
-        end
-      end
-    end
-
     context 'if the article has more possible positions' do
       let(:element_1) { double('additional_element_1', type: :element_1) }
       let(:element_2) { double('additional_element_2', type: :element_2) }
@@ -117,6 +83,38 @@ describe ArticleJSON::Utils::AdditionalElementPlacer do
       end
     end
 
+    context 'if only one element is inserted' do
+      let(:element_1) { double('additional_element_1', type: :element_1) }
+      let(:additional_elements) { [element_1] }
+
+      include_examples 'for properly added additional elements' do
+        let(:expected_article_elements) do
+          [
+            paragraph,
+            image,
+            image,
+            paragraph,
+            # Possible additional element position
+            paragraph,
+            # Possible additional element position
+            paragraph,
+            # Possible additional element position
+            paragraph,
+            element_1, # inserted element
+            paragraph,
+            # Possible additional element position
+            paragraph,
+            quote,
+            quote,
+            paragraph,
+            # Possible additional element position
+            paragraph,
+            embed,
+          ]
+        end
+      end
+    end
+
     context 'if the article has just enough possible positions' do
       let(:element_1) { double('additional_element_1', type: :element_1) }
       let(:element_2) { double('additional_element_2', type: :element_2) }
@@ -137,20 +135,21 @@ describe ArticleJSON::Utils::AdditionalElementPlacer do
             paragraph,
             element_1, # inserted element
             paragraph,
+            # TODO: Leaving this empty is a known issue with the algorithm
+            paragraph,
             element_2, # inserted element
             paragraph,
             element_3, # inserted element
             paragraph,
             element_4, # inserted element
             paragraph,
+            quote,
+            quote,
+            paragraph,
             element_5, # inserted element
             paragraph,
-            quote,
-            quote,
-            paragraph,
-            element_6, # inserted element
-            paragraph,
             embed,
+            element_6, # inserted element
           ]
         end
       end


### PR DESCRIPTION
While the previous algorithm was better in saturating articles with additional elements it did not perform well when placing a single additional element into an article, this was always placed at the end.

Considering the known use-cases of this algorithm (placing ads or CTA forms within an article), it seems more common that single elements are placed than that the article is being saturated with additional elements.

For this, also add `#length` methods on `Text` and `Paragraph` elements: Similar to the `String#length` method these methods return the number of characters contained by the element. For compatibility with the `String` methods, also add the alias `#size`.

Outline of the new algorithm:
1. It calculates every how many characters (only considering paragraphs) an additional element should be inserted, given the number of additional elements provided
2. It then iterates over the existing elements within the article, inserting them into the resulting, merged article
3. As soon as it has passed the right amount characters, it checks if the current position is eligible for inserting an additional element (the previous element needs to be a paragraph and the following needs to be either a paragraph or a headline)
  a. If so, it inserts the additional element and recalculates in how many characters the next element should be inserted, based on the remaining number of characters and remaining additional elements
  b. If not, it keeps iterating over the article until it finds an eligible position and only then inserts the additional element and recalculates the number of characters until the next insertion
4. If there are still additional elements remaining which couldn't be inserted (due to not finding enough eligible positions), they are appended to the end of the article