### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Changelog
 
-## WIP
-- Add an exporter for Facebook Instant Articles
-- Add support to exporters for `caption` elements that are an empty array
-- GDoc Importer: Support `[no-caption]` text, returns empty caption for element
-- Fix AMP export of Twitter tweets
-- Add a plain text exporter
+## 0.3.0 - 2017/11/21
+In this third bigger release we **added support**:
+- For exporting articles in the Facebook Instant Article format
+- For exporting articles in a plain text format
+- To all exporters for `caption` elements that are an empty array
+- For `[no-caption]` text in _Google Documents_ below elements (like images or embed URLs), this now returns empty caption for element
+
+**Improvements** were done regarding additional element placement:
+- Rework algorithm to place additional elements to better support placing a single element
 - Improve behavior of multiple calls to `Article#place_additional_elements`
+
+One potentially **breaking change** was added:
 - Remove deprecated `#register_html_element_exporter`, use `#register_element_exporters` instead
-- Rework algorithm to place additional elements to support better placement
+
+**Fixes**:
+- Fix AMP export of Twitter tweets
 
 ## 0.2.1 - 2017/11/08
 **Fix**: Handle non-successful OEmbed responses by rendering message

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/spec/article_json/article_spec.rb
+++ b/spec/article_json/article_spec.rb
@@ -142,7 +142,7 @@ describe ArticleJSON::Article do
   shared_context 'for a correctly parsed Hash' do
     let(:example_hash) do
       {
-        article_json_version: '0.2.1',
+        article_json_version: '0.3.0',
         content: [
           {
             type: :paragraph,

--- a/spec/article_json/import/google_doc/html/parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/parser_spec.rb
@@ -18,7 +18,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
       let(:json) do
         <<-json
           {
-            "article_json_version": "0.1.0",
+            "article_json_version": "0.3.0",
             "content": [
               {
                 "type": "text_box",
@@ -55,7 +55,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
       let(:json) do
         <<-json
           {
-            "article_json_version": "0.1.0",
+            "article_json_version": "0.3.0",
             "content": [
               {
                 "type": "paragraph",

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.2.1",
+  "article_json_version": "0.3.0",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
In this third bigger release we **added support**:
- For exporting articles in the Facebook Instant Article format
- For exporting articles in a plain text format
- To all exporters for `caption` elements that are an empty array
- For `[no-caption]` text in _Google Documents_ below elements (like images or embed URLs), this now returns empty caption for element

**Improvements** were done regarding additional element placement:
- Rework algorithm to place additional elements to better support placing a single element
- Improve behavior of multiple calls to `Article#place_additional_elements`

One potentially **breaking change** was added:
- Remove deprecated `#register_html_element_exporter`, use `#register_element_exporters` instead

**Fixes**:
- Fix AMP export of Twitter tweets