### PR TITLE
Fix additional element placement on empty articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## WIP
+- Fix additional element placement on empty articles
+
 ## 0.3.0 - 2017/11/21
 In this third bigger release we **added support**:
 - For exporting articles in the Facebook Instant Article format

--- a/lib/article_json/utils/additional_element_placer.rb
+++ b/lib/article_json/utils/additional_element_placer.rb
@@ -10,7 +10,7 @@ module ArticleJSON
       # @param [Array[ArticleJSON::Article::Elements::Base]] elements
       # @param [Array[Object]] additional_elements
       def initialize(elements, additional_elements)
-        @elements = elements.dup
+        @elements = elements&.dup
         @additional_elements = additional_elements
       end
 
@@ -39,6 +39,7 @@ module ArticleJSON
       #
       # @return [Array[ArticleJSON::Elements::Base|Object]]
       def merge_elements
+        return @additional_elements if @elements.nil? || @elements.empty?
         remaining_elements = @additional_elements.dup
         next_in = insert_next_element_in(0, remaining_elements)
         characters_passed = 0

--- a/spec/article_json/utils/additional_element_placer_spec.rb
+++ b/spec/article_json/utils/additional_element_placer_spec.rb
@@ -200,5 +200,31 @@ describe ArticleJSON::Utils::AdditionalElementPlacer do
         end
       end
     end
+
+    context 'when the original article only contains one element' do
+      let(:text) { ArticleJSON::Elements::Text.new(content: 'Lorem Ipsum ') }
+      let(:paragraph) { ArticleJSON::Elements::Paragraph.new(content: [text]) }
+      let(:article_elements) { [paragraph] }
+      let(:element_1) { double('additional_element_1', type: :element_1) }
+      let(:element_2) { double('additional_element_2', type: :element_2) }
+      let(:additional_elements) { [element_1, element_2] }
+      it { should eq [*article_elements, *additional_elements] }
+    end
+
+    context 'when the original article is empty' do
+      let(:article_elements) { [] }
+      let(:element_1) { double('additional_element_1', type: :element_1) }
+      let(:element_2) { double('additional_element_2', type: :element_2) }
+      let(:additional_elements) { [element_1, element_2] }
+      it { should eq additional_elements }
+    end
+
+    context 'when the original article elements are `nil`' do
+      let(:article_elements) { nil }
+      let(:element_1) { double('additional_element_1', type: :element_1) }
+      let(:element_2) { double('additional_element_2', type: :element_2) }
+      let(:additional_elements) { [element_1, element_2] }
+      it { should eq additional_elements }
+    end
   end
 end


### PR DESCRIPTION
If an article contains no elements but additional elements are place on it, it previously introduced a `nil` element into the article elements. This in turn then led the exporters to crash.

Now we check if there are any elements in the original article and if not, the element place simply returns the additional elements.