### PR TITLE
Prepare 0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## WIP
-- Fix additional element placement on empty articles
+## 0.3.1 - 2017/11/29
+- **Fix:** prevent `nil` elements when placing additional element on empty articles
 
 ## 0.3.0 - 2017/11/21
 In this third bigger release we **added support**:

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/article_json/article_spec.rb
+++ b/spec/article_json/article_spec.rb
@@ -150,7 +150,7 @@ describe ArticleJSON::Article do
   shared_examples_for 'a correctly parsed Hash' do
     let(:example_hash) do
       {
-        article_json_version: '0.3.0',
+        article_json_version: ArticleJSON::VERSION,
         content: [
           {
             type: :paragraph,
@@ -175,7 +175,9 @@ describe ArticleJSON::Article do
   end
 
   shared_examples_for 'a correctly parsed empty Hash' do
-    let(:example_hash) { { article_json_version: '0.3.0', content: [] } }
+    let(:example_hash) do
+      { article_json_version: ArticleJSON::VERSION, content: [] }
+    end
     it { should be_a described_class }
     it('contains the right content') { expect(subject.elements).to be_empty }
     it('is reversible') { expect(subject.to_h).to eq example_hash }

--- a/spec/article_json/import/google_doc/html/parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/parser_spec.rb
@@ -16,9 +16,9 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
     context 'when a text box is not closed' do
       let(:html) { File.read('spec/fixtures/google_doc_unclosed_textbox.html') }
       let(:json) do
-        <<-json
+        <<~JSON
           {
-            "article_json_version": "0.3.0",
+            "article_json_version": "#{ArticleJSON::VERSION}",
             "content": [
               {
                 "type": "text_box",
@@ -45,7 +45,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
               }
             ]
           }
-        json
+        JSON
       end
       it { should eq minified_json }
     end
@@ -53,9 +53,9 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
     context 'when paragraphs contain no text' do
       let(:html) { File.read('spec/fixtures/google_doc_empty_paragraphs.html') }
       let(:json) do
-        <<-json
+        <<~JSON
           {
-            "article_json_version": "0.3.0",
+            "article_json_version": "#{ArticleJSON::VERSION}",
             "content": [
               {
                 "type": "paragraph",
@@ -71,7 +71,7 @@ describe ArticleJSON::Import::GoogleDoc::HTML::Parser do
               }
             ]
           }
-        json
+        JSON
       end
       it { should eq minified_json }
     end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.3.0",
+  "article_json_version": "0.3.1",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
Contains one **fix**: prevent `nil` elements when placing additional element on empty articles

Also make version number in specs dynamic