### PR TITLE
Fix issue when inserting elements into article with empty paragraph.

### DIFF
--- a/lib/article_json/utils/additional_element_placer.rb
+++ b/lib/article_json/utils/additional_element_placer.rb
@@ -47,6 +47,7 @@ module ArticleJSON
           .each_cons(2)
           .each_with_object([]) do |(element, next_element), result|
             result << element
+            next if remaining_elements.empty?
             characters_passed += element.length if element.respond_to?(:length)
             next_in -= element.length if element.respond_to?(:length)
             if insert_here?(next_in, element, next_element)

--- a/spec/article_json/utils/additional_element_placer_spec.rb
+++ b/spec/article_json/utils/additional_element_placer_spec.rb
@@ -201,6 +201,27 @@ describe ArticleJSON::Utils::AdditionalElementPlacer do
       end
     end
 
+    context 'if the article ends with empty elements' do
+      let(:additional_elements) { [] }
+      let(:empty) { ArticleJSON::Elements::Paragraph.new(content: ['']) }
+
+      include_examples 'for properly added additional elements' do
+        let(:article_elements) do
+          [
+            paragraph,
+            empty,
+          ]
+        end
+        let(:expected_article_elements) do
+          [
+            paragraph,
+            empty,
+          ]
+        end
+      end
+    end
+
+
     context 'when the original article only contains one element' do
       let(:text) { ArticleJSON::Elements::Text.new(content: 'Lorem Ipsum ') }
       let(:paragraph) { ArticleJSON::Elements::Paragraph.new(content: [text]) }


### PR DESCRIPTION
When the article ended in an empty element, the code tried to add
more than addition elements than available, inserting a nil element.
This avoids the problem.