### PR TITLE
Prepare 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.2 - 2017/12/06
+- Another **fix** to prevent `nil` elements when placing additional elements on articles that end with empty paragraphs
+
 ## 0.3.1 - 2017/11/29
 - **Fix:** prevent `nil` elements when placing additional element on empty articles
 

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.3.1",
+  "article_json_version": "0.3.2",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
Contains another fix to prevent `nil` elements when placing additional elements on articles that end with empty paragraphs added by @christofdamian in PR #129 – thanks for the fix! 