### PR TITLE
Only include slug from the soundcloud URL.

### DIFF
--- a/lib/article_json/import/google_doc/html/embedded_soundcloud_parser.rb
+++ b/lib/article_json/import/google_doc/html/embedded_soundcloud_parser.rb
@@ -17,7 +17,7 @@ module ArticleJSON
               %r{
                 ^\S*                    # all protocols & sub domains
                 soundcloud\.com/        # domain
-                (?<id>.+)               # the slug of the user / track
+                (?<id>[-/0-9a-z]+)      # the slug of the user / track
               }xi
             end
           end

--- a/spec/article_json/import/google_doc/html/embedded_soundcloud_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/embedded_soundcloud_parser_spec.rb
@@ -9,6 +9,8 @@ describe ArticleJSON::Import::GoogleDoc::HTML::EmbeddedSoundcloudParser do
     let(:url_examples) do
       %W(
         https://soundcloud.com/#{expected_embed_id}
+        https://soundcloud.com/#{expected_embed_id}\u{a0}
+        https://soundcloud.com/#{expected_embed_id}?something=else
       )
     end
   end


### PR DESCRIPTION
Changed the regex to only except the slug part from the URL and
ignore any trailing characters.