### PR TITLE
Prepare release 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 0.3.4 - 2018/5/10
-- Only include slug from the soundcloud URL
+- **Fix:** Only include slug from the soundcloud URL in google doc parser
 
 ## 0.3.3 - 2018/4/12
 - Support embedding SoundCloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.3.4 - 2018/5/10
+- Only include slug from the soundcloud URL
+
 ## 0.3.3 - 2018/4/12
 - Support embedding SoundCloud
 

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.3.3",
+  "article_json_version": "0.3.4",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
- Only include slug from the soundcloud URL