### PR TITLE
Export the image element href attribute as a link

### DIFF
--- a/lib/article_json/export/common/html/elements/image.rb
+++ b/lib/article_json/export/common/html/elements/image.rb
@@ -7,22 +7,36 @@ module ArticleJSON
             include ArticleJSON::Export::Common::HTML::Elements::Shared::Caption
             include ArticleJSON::Export::Common::HTML::Elements::Shared::Float
 
-            # Generate the `<figure>` node containing the image and caption
+            # Generate the `<figure>` node containing the image and caption or
+            # an `<a>` node containing the `<figure>` node if href is present.
             # @return [Nokogiri::XML::Element]
             def export
+              figure_node
+            end
+
+            private
+
+            # @return [Nokogiri::XML::NodeSet]
+            def figure_node
               create_element(:figure, node_opts) do |figure|
-                figure.add_child(image_node)
+                node =  @element.href.present? ? href_node : image_node
+                figure.add_child(node)
                 if @element.caption&.any?
                   figure.add_child(caption_node(:figcaption))
                 end
               end
             end
 
-            private
-
             # @return [Nokogiri::XML::NodeSet]
             def image_node
               create_element(:img, src: @element.source_url)
+            end
+
+            # @return [Nokogiri::XML::NodeSet]
+            def href_node
+              create_element(:a, href: @element.href) do |a|
+                a.add_child(image_node)
+              end
             end
 
             # @return [Hash]

--- a/spec/article_json/export/html/elements/image_spec.rb
+++ b/spec/article_json/export/html/elements/image_spec.rb
@@ -5,10 +5,12 @@ describe ArticleJSON::Export::HTML::Elements::Image do
     ArticleJSON::Elements::Image.new(
       source_url: '/foo/bar.jpg',
       caption: caption,
-      float: float
+      float: float,
+      href: url
     )
   end
   let(:float) { nil }
+  let(:url) { nil }
   let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
 
   describe '#export' do
@@ -43,6 +45,34 @@ describe ArticleJSON::Export::HTML::Elements::Image do
     context 'when no caption is provided' do
       let(:caption) { [] }
       let(:expected_html) { '<figure><img src="/foo/bar.jpg"></figure>' }
+      it { should eq expected_html }
+    end
+
+    context 'when the image has an href' do
+      let(:caption) { [] }
+      let(:url) { 'http://devex.com' }
+      let(:expected_html) do
+        '<figure><a href="http://devex.com">' \
+          '<img src="/foo/bar.jpg"></a></figure>'
+      end
+      it { should eq expected_html }
+    end
+
+    context 'when the image has an href and a caption with a link' do
+      let(:caption) do
+        [
+          ArticleJSON::Elements::Text.new(
+            content: 'Foo Bar',
+            href: 'http://foo.io'
+          )
+        ]
+      end
+      let(:url) { 'http://devex.com' }
+      let(:expected_html) do
+        '<figure><a href="http://devex.com">' \
+        '<img src="/foo/bar.jpg"></a>' \
+        '<figcaption><a href="http://foo.io">Foo Bar</a></figcaption></figure>'
+      end
       it { should eq expected_html }
     end
   end


### PR DESCRIPTION
If the image element has an href attribute, we nest the figure tag of the image
inside a link.