### PR TITLE
Prepare release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.3.5 - 2018/12/12
+- **Improvements** to import and export image links from Google Docs
+- Import image `href`` from caption text using a custom tag
+- Export the image element href attribute as a link
+
 ## 0.3.4 - 2018/5/10
 - **Fix:** Only include slug from the soundcloud URL in google doc parser
 

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.3.4'
+  VERSION = '0.3.5'
 end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.3.4",
+  "article_json_version": "0.3.5",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
**Improvements** to import and export image links from Google Docs
- Import image `href`` from caption text using a custom tag
- Export the image element href attribute as a link