### PR TITLE
Use https for soundcloud oembed api

### DIFF
--- a/lib/article_json/utils/o_embed_resolver/soundcloud.rb
+++ b/lib/article_json/utils/o_embed_resolver/soundcloud.rb
@@ -11,7 +11,7 @@ module ArticleJSON
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
-          "http://soundcloud.com/oembed?url=#{source_url}&format=json"
+          "https://soundcloud.com/oembed?url=#{source_url}&format=json"
         end
 
         # The URL of the element

--- a/spec/article_json/utils/o_embed_resolver/soundcloud_spec.rb
+++ b/spec/article_json/utils/o_embed_resolver/soundcloud_spec.rb
@@ -11,7 +11,7 @@ describe ArticleJSON::Utils::OEmbedResolver::Soundcloud do
       )
     end
     let(:expected_oembed_url) do
-      'http://soundcloud.com/oembed?' \
+      'https://soundcloud.com/oembed?' \
       "url=https://soundcloud.com/#{embed_id}&format=json"
     end
     let(:oembed_response) do

--- a/spec/support/oembed_request_mocks.rb
+++ b/spec/support/oembed_request_mocks.rb
@@ -74,7 +74,7 @@ module OembedRequestStubs
   def stub_oembed_soundcloud_request(additional_headers = {}, custom_body: nil,
                                 error: false)
     stub_oembed_request(
-      'http://soundcloud.com/oembed?url=https://soundcloud.com/rich-the-kid/plug-walk-1&format=json',
+      'https://soundcloud.com/oembed?url=https://soundcloud.com/rich-the-kid/plug-walk-1&format=json',
       custom_body || File.read('spec/fixtures/soundcloud_oembed.json'),
       additional_headers,
       error: error


### PR DESCRIPTION
After the last change to soundclued oembed, a plain http call would
send a redirection to an https request, making the player to fail. To
fix this, we use https instead.