### PR TITLE
Prepare version 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.3.7 - 2019/8/21
+- **Fix:** Only use https for soundcloud oembed api
+
 ## 0.3.6 - 2019/8/6
 - **Improvement** Add tags support in text_box element.
 

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.3.6'
+  VERSION = '0.3.7'
 end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.3.6",
+  "article_json_version": "0.3.7",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
**Fix** Only use https for souncloud oembed api.