### PR TITLE
Fix [image-link-to: ] tag removal

### DIFF
--- a/lib/article_json/import/google_doc/html/image_parser.rb
+++ b/lib/article_json/import/google_doc/html/image_parser.rb
@@ -88,9 +88,8 @@ module ArticleJSON
               .first
               .content = @caption_node.children.first.content.gsub('[image-link-to:', '')
             @caption_node
-              .children
-              .last
-              .content = @caption_node.children.last.content.gsub('] ', '')
+              .children[2]
+              .content = @caption_node.children[2].content.gsub('] ', '')
             @caption_node.children.search('a').remove
           end
 

--- a/spec/article_json/import/google_doc/html/image_parser_spec.rb
+++ b/spec/article_json/import/google_doc/html/image_parser_spec.rb
@@ -184,17 +184,19 @@ describe ArticleJSON::Import::GoogleDoc::HTML::ImageParser do
 
     context 'when the caption is `[image-link-to]`' do
       let(:text) { 'Original caption text' }
+      let(:second_text) { 'second text' }
       let(:caption_fragment) do
         "<p><span> [image-link-to: </span>" \
         "<span><a href=\"http://devex.com\">http://devex.com</a></span>" \
-        "<span>] #{text}</span></p>"
+        "<span>] #{text}</span><span>#{second_text}</span></p>"
       end
 
       it 'returns an empty list' do
         expect(subject).to be_an Array
-        expect(subject.size).to eq 1
+        expect(subject.size).to eq 2
         expect(subject).to all be_a ArticleJSON::Elements::Text
         expect(subject.first.content).to eq text
+        expect(subject.last.content).to eq second_text
       end
     end
 


### PR DESCRIPTION
When trying to remove the [image-link-to: ] tag after parsing an image caption,
we used the last element of the caption childrens, so if there was more text
after the tag, we tried to remove the `]` from the text at the end instead of
from the proper child.