### PR TITLE
Prepare release 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 0.3.8 - 2020/7/31
+- **Improvements:**
+- Add a script to update oembed stubs fixtures.
+- Support for `alt` attribute in images.
+
+- **Fix:** Fix a bug when using the `[image-link-to: ]` tag.
+
 ## 0.3.7 - 2019/8/21
 - **Fix:** Only use https for soundcloud oembed api
 

--- a/lib/article_json/version.rb
+++ b/lib/article_json/version.rb
@@ -1,3 +1,3 @@
 module ArticleJSON
-  VERSION = '0.3.7'
+  VERSION = '0.3.8'
 end

--- a/spec/fixtures/reference_document_parsed.json
+++ b/spec/fixtures/reference_document_parsed.json
@@ -1,5 +1,5 @@
 {
-  "article_json_version": "0.3.7",
+  "article_json_version": "0.3.8",
   "content": [
     {
       "type": "paragraph",


### PR DESCRIPTION
**Improvements:**
- Add a script to update oembed stubs fixtures.
- Supoort for `alt` attribute in images.

**Fix:** Fix a bug when using the `[image-link-to: ]` tag.