### PR TITLE
Fix URL for Facebook AMP embed

### DIFF
--- a/lib/article_json/export/amp/elements/embed.rb
+++ b/lib/article_json/export/amp/elements/embed.rb
@@ -69,7 +69,7 @@ module ArticleJSON
 
           # @return [Nokogiri::XML::Element]
           def facebook_node
-            url = "#{@element.oembed_data[:author_url]}videos/#{@element.embed_id}"
+            url = "#{@element.oembed_data[:author_url]}/videos/#{@element.embed_id}"
             create_element('amp-facebook',
                            'data-embedded-as' => 'video',
                            'data-href' => url,

--- a/spec/fixtures/facebook_video_oembed.json
+++ b/spec/fixtures/facebook_video_oembed.json
@@ -1,6 +1,6 @@
 {
   "author_name": "Devex",
-  "author_url": "https://www.facebook.com/Devex/",
+  "author_url": "https://www.facebook.com/Devex",
   "provider_url": "https://www.facebook.com",
   "provider_name": "Facebook",
   "success": true,


### PR DESCRIPTION
The new Facebook API endpoint doesn't include a trailing slash in the author
URL. This led to a broken URL for the AMP embed of Facebook videos.

For reference the legacy oembed documentation includes it in the example.
https://www.facebook.com/Devex/videos/231586811299265

To see the new result you need to enter an access token and video url here:
https://developers.facebook.com/tools/explorer/?method=GET&path=oembed_video