### PR TITLE
Fixes bug with youtube embed videos

### DIFF
--- a/lib/article_json/utils/o_embed_resolver/youtube_video.rb
+++ b/lib/article_json/utils/o_embed_resolver/youtube_video.rb
@@ -11,7 +11,7 @@ module ArticleJSON
         # The URL for the oembed API call
         # @return [String]
         def oembed_url
-          "http://www.youtube.com/oembed?format=json&url=#{source_url}"
+          "https://www.youtube.com/oembed?format=json&url=#{source_url}"
         end
 
         # The video URL of the element


### PR DESCRIPTION
Youtube oembed api now requires to use ssl to work properly, but we were using
just plain http.