### PR TITLE
BAN-1718 New param with to allow custom placer

### DIFF
--- a/lib/article_json/article.rb
+++ b/lib/article_json/article.rb
@@ -14,7 +14,7 @@ module ArticleJSON
     def elements
       @elements ||= begin
         if @additional_elements.any?
-          ArticleJSON::Utils::AdditionalElementPlacer
+          @additional_element_placer_class
             .new(@article_elements, @additional_elements)
             .merge_elements
         else
@@ -91,10 +91,18 @@ module ArticleJSON
     # article. If the method is called multiple times, the order of additional
     # elements is maintained.
     # @param [Object] additional_elements
-    def place_additional_elements(additional_elements)
+    # @param [Class<#merge_elements>] with - The passes class's `#initialize` method needs
+    #                                        to accept two lists of elements. See
+    #                                        `ArticleJSON::Utils::AdditionalElementPlacer`
+    #                                        for reference.
+    def place_additional_elements(
+      additional_elements,
+      with: ArticleJSON::Utils::AdditionalElementPlacer
+    )
       # Reset the `#elements` method memoization
       @elements = nil
       @additional_elements.concat(additional_elements)
+      @additional_element_placer_class = with
     end
 
     class << self


### PR DESCRIPTION
With this optional param we can pass a different placer that has a different algorithm to distribute the elements in the article.

When not passing anything it will use the default one: `ArticleJSON::Utils::AdditionalElementPlacer` so this change won't break anything.

[BAN-1718 Edit article_json gem to make element location configurable](https://mydevex.atlassian.net/browse/BAN-1718)