### PR TITLE
Add support for adding images via URL

### DIFF
--- a/lib/article_json/import/google_doc/html/image_parser.rb
+++ b/lib/article_json/import/google_doc/html/image_parser.rb
@@ -22,25 +22,31 @@ module ArticleJSON
           # The value of the image's `alt` attribute
           # @return [String]
           def alt
+            return '' if image_url?
+
             image_node.attribute('alt')&.value || ''
           end
 
           # The value of the image's `src` attribute
           # @return [String]
           def source_url
+            return @node.inner_text.strip if image_url?
+
             image_node.attribute('src').value
           end
 
           # The node of the actual image
           # @return [Nokogiri::HTML::Node]
           def image_node
-            @node.xpath('.//img').first
+            return @image_node if defined? @image_node
+
+            @image_node = @node.xpath('.//img').first
           end
 
           # Check if the image is floating (left, right or not at all)
           # @return [Symbol]
           def float
-            super if floatable_size?
+            super if image_url? || floatable_size?
           end
 
           # Extracts an href from the tag [image-link-to: url]) if present
@@ -80,6 +86,7 @@ module ArticleJSON
           def href_regexp
             %r{\[image-link-to:\s+(?<url>.*?)\]}
           end
+
           # Check if the image's width can be determined and is less than 500px
           # This is about 3/4 of the google document width...
           # @return [Boolean]
@@ -100,6 +107,13 @@ module ArticleJSON
                 match = image_node.attribute('style').value.match(regex)
                 match['px'].to_i if match && match['px']
               end
+          end
+
+          # When the current node doesn't contain an actual image tag,
+          # we're dealing with an image URL
+          # @return [Boolean]
+          def image_url?
+            image_node.nil?
           end
         end
       end

--- a/lib/article_json/import/google_doc/html/node_analyzer.rb
+++ b/lib/article_json/import/google_doc/html/node_analyzer.rb
@@ -88,7 +88,17 @@ module ArticleJSON
           # @return [Boolean]
           def image?
             return @is_image if defined? @is_image
-            @is_image = node.xpath('.//img').length > 0
+            @is_image = image_url? || node.xpath('.//img').length > 0
+          end
+
+          # Check if the node contains an image URL
+          # @return [Boolean]
+          def image_url?
+            return @is_image_url if defined? @is_image_url
+
+            text = node.inner_text.strip
+            url_regexp = %r{https?:\/\/\S+\.(?:jpg|jpeg|png|gif)}i
+            @is_image_url = !!(url_regexp =~ text)
           end
 
           # Check if the node contains an embedded element

--- a/spec/article_json/import/google_doc/html/node_analyzer_spec.rb
+++ b/spec/article_json/import/google_doc/html/node_analyzer_spec.rb
@@ -178,8 +178,54 @@ describe ArticleJSON::Import::GoogleDoc::HTML::NodeAnalyzer do
       it { should be true }
     end
 
+    context 'when the node contains an image url' do
+      let(:image_url) { 'https://devex.com/images/foo.png' }
+      let(:xml_fragment) { "<p><span><a href=\"#{image_url}\">#{image_url}</a></span></p>" }
+      it { should be true }
+    end
+
     context 'when the node does *not* have a nested image tag' do
       let(:xml_fragment) { '<p><span>no image here</span></p>' }
+      it { should be false }
+    end
+  end
+
+  describe '#image_url?' do
+    subject { node.image_url? }
+
+    context 'when the node contains an image URL' do
+      image_url_list = %w[
+          https://devex.com/images/foo.jpeg
+          http://devex.com/images/foo.jpeg
+          https://devex.com/images/foo.jpg
+          http://devex.com/images/foo.jpg
+          https://devex.com/images/foo.png
+          http://devex.com/images/foo.png
+          https://devex.com/images/foo.gif
+          http://devex.com/images/foo.gif
+        ]
+      image_url_list.each do |image_url|
+        context("and the URL is '#{image_url}'") do
+          let(:xml_fragment) do
+            <<-html
+              <span><a href="https://www.google.com/url?q=#{image_url}">#{image_url}</a></span>
+            html
+          end
+
+          it { should be true }
+        end
+      end
+    end
+
+    context 'when the node contain a non-image URL' do
+      let(:xml_fragment) { '<span><a href="https://devex.com">foo bar</a></span>' }
+
+      it { should be false }
+    end
+
+    context 'when the node does not contain any URL' do
+      let(:xml_fragment) { '<span>nothing to see here</span>' }
+
       it { should be false }
     end
   end


### PR DESCRIPTION
Recently Google changed how images of an HTML export are accessed, the URLs became much longer and in certain cases require an active session to be accessed.

To allow for an alternative way of embedding images in news articles, we now added support to specify external images via the URL:
- When the image's URL is left aligned, it will be displayed as a small image with text floating around it.
- By aligning image URLs to the right they will later on be displayed on the right side of the article.
- URLs for large images that are supposed to take up the full width within the News Details need to be centered within the Google Document.

The caption works exactly as it does for normal images, which means they are specified in the following paragraph or can be skipped with `[no-caption]`.

Also can these images be linked by specifying `[image-link-to: URL]` in the caption paragraph.


Here is an example of how the Google Document and final result look like:
![image](https://user-images.githubusercontent.com/1056502/233615413-6269ac7e-a128-4f21-9370-b83e156194d6.png)
![image](https://user-images.githubusercontent.com/1056502/233615514-000fbe1b-2d5c-45af-b951-40b89bb34791.png)

