### PR TITLE
BAN-2027 Add Apple News text, paragraph and headlines elements

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -77,6 +77,11 @@ require_relative 'article_json/export/html/elements/quote'
 require_relative 'article_json/export/html/elements/embed'
 require_relative 'article_json/export/html/exporter'
 
+require_relative 'article_json/export/apple_news/elements/base'
+require_relative 'article_json/export/apple_news/elements/text'
+require_relative 'article_json/export/apple_news/elements/heading'
+require_relative 'article_json/export/apple_news/elements/paragraph'
+
 require_relative 'article_json/export/amp/elements/base'
 require_relative 'article_json/export/amp/elements/text'
 require_relative 'article_json/export/amp/elements/paragraph'

--- a/lib/article_json/export/apple_news/elements/base.rb
+++ b/lib/article_json/export/apple_news/elements/base.rb
@@ -1,0 +1,53 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class Base
+          include ArticleJSON::Export::Common::Elements::Base
+
+          # Export the given element. Dynamically looks up the right
+          # export-element-class, instantiates it and then calls the `#export`
+          # method.
+          # Defaults to nil, e.g. if no exporter is specified for the given
+          # type.
+          # @return [String]
+          def export
+            super || nil
+          end
+
+          class << self
+            # Return the module namespace this class and its subclasses are
+            # nested within.
+            # @return [Module]
+            def namespace
+              ArticleJSON::Export::AppleNews::Elements
+            end
+
+            private
+
+            # The format this exporter is returning. This is used to determine
+            # which custom element exporters should be applied from the
+            # configuration.
+            # @return [Symbol]
+            def export_format
+              :apple_news
+            end
+
+            def default_exporter_mapping
+              {
+                text: namespace::Text,
+                paragraph: namespace::Paragraph,
+                heading: namespace::Heading,
+                list: nil,
+                quote: nil,
+                image: nil,
+                embed: nil,
+                text_box: nil
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/apple_news/elements/heading.rb
+++ b/lib/article_json/export/apple_news/elements/heading.rb
@@ -1,0 +1,30 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class Heading < Base
+          # Headline
+          # @return [Hash]
+          def export
+            {
+              role: role,
+              text: @element.content
+            }
+          end
+
+          private
+
+          # The role of text component for adding a heading. (Required) Always
+          # one of these roles for this component: heading, heading1, heading2,
+          # heading3, heading4, heading5, or heading6.
+          # @return [String]
+          def role
+            return 'heading' if @element.level.nil?
+
+            "heading#{@element.level}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/apple_news/elements/paragraph.rb
+++ b/lib/article_json/export/apple_news/elements/paragraph.rb
@@ -1,0 +1,32 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class Paragraph < Base
+          # Generate the paragraph node with its containing text elements
+          # @return [Hash]
+          def export
+            {
+              role: 'body',
+              text: text
+            }
+          end
+
+          private
+
+          # Get the exporter class for text elements
+          # @return [ArticleJSON::Export::Common::HTML::Elements::Base]
+          def text_exporter
+            self.class.exporter_by_type(:text)
+          end
+
+          def text
+            @element.content.map do |child_element|
+              text_exporter.new(child_element).export
+            end.join
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/apple_news/elements/text.rb
+++ b/lib/article_json/export/apple_news/elements/text.rb
@@ -1,0 +1,21 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class Text < Base
+          include ArticleJSON::Export::Common::HTML::Elements::Base
+          include ArticleJSON::Export::Common::HTML::Elements::Text
+
+          # A Nokogiri object is returned with`super`, which is is then
+          # returned as a either a string or as HTML (when not plain text),
+          # both of which are compatible with Apple News format. Takes into
+          #  account bold, italic and href.
+          # @return [String]
+          def export
+            super.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/export/apple_news/elements/base_spec.rb
+++ b/spec/article_json/export/apple_news/elements/base_spec.rb
@@ -1,0 +1,74 @@
+describe ArticleJSON::Export::AppleNews::Elements::Base do
+  subject(:element) { described_class.new(source_element) }
+
+  describe '#export' do
+    subject { element.export }
+
+    let(:sample_text) { ArticleJSON::Elements::Text.new(content: 'Foo Bar') }
+
+    context 'when the source element is a text' do
+      let(:source_element) { sample_text }
+      it { should eq 'Foo Bar' }
+    end
+
+    context 'when the source element is a heading' do
+      let(:source_element) do
+        ArticleJSON::Elements::Heading.new(content: 'Foo Bar', level: 1)
+      end
+      let(:heading) { { role: 'heading1', text: 'Foo Bar' } }
+      it { should eq heading }
+    end
+
+    context 'when the source element is a paragraph' do
+      let(:source_element) do
+        ArticleJSON::Elements::Paragraph.new(content: [sample_text])
+      end
+      let(:paragraph) { { role: 'body', text: 'Foo Bar' } }
+      it { should eq paragraph }
+    end
+  end
+
+  describe '.build' do
+    subject { described_class.build(element) }
+
+    context 'when the element type is text' do
+      let(:element) { ArticleJSON::Elements::Text.new(content: '') }
+      it { should be_a ArticleJSON::Export::AppleNews::Elements::Text }
+    end
+
+    context 'when the element type is heading' do
+      let(:element) { ArticleJSON::Elements::Heading.new(content: 1, level: 1) }
+      it { should be_a ArticleJSON::Export::AppleNews::Elements::Heading }
+    end
+
+    context 'when the element type is paragraph' do
+      let(:element) { ArticleJSON::Elements::Paragraph.new(content: []) }
+      it { should be_a ArticleJSON::Export::AppleNews::Elements::Paragraph }
+    end
+  end
+
+  describe '.exporter_by_type' do
+    subject { described_class.exporter_by_type(element_type) }
+
+    context 'when the element type is text' do
+      let(:element_type) { :text }
+      it { should be ArticleJSON::Export::AppleNews::Elements::Text }
+    end
+
+    context 'when the element type is heading' do
+      let(:element_type) { :heading }
+      it { should be ArticleJSON::Export::AppleNews::Elements::Heading }
+    end
+
+    context 'when the element type is paragraph' do
+      let(:element_type) { :paragraph }
+      it { should be ArticleJSON::Export::AppleNews::Elements::Paragraph }
+    end
+  end
+
+  describe '.namespace' do
+    subject { described_class.namespace }
+    it { should be_a Module }
+    it { should eq ArticleJSON::Export::AppleNews::Elements }
+  end
+end

--- a/spec/article_json/export/apple_news/elements/heading_spec.rb
+++ b/spec/article_json/export/apple_news/elements/heading_spec.rb
@@ -1,0 +1,19 @@
+describe ArticleJSON::Export::AppleNews::Elements::Heading do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Heading.new(content: 'Foo Bar', level: level)
+  end
+
+  describe '#export' do
+    subject { element.export }
+
+    (1..6).each do |i|
+      context "when the heading level is #{i}" do
+        let(:level) { i }
+        let(:heading) { { role: "heading#{i}", text: 'Foo Bar' } }
+        it { should eq heading }
+      end
+    end
+  end
+end

--- a/spec/article_json/export/apple_news/elements/paragraph_spec.rb
+++ b/spec/article_json/export/apple_news/elements/paragraph_spec.rb
@@ -1,0 +1,21 @@
+describe ArticleJSON::Export::AppleNews::Elements::Paragraph do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Paragraph.new(content: [content_1, content_2])
+  end
+  let(:content_1) do
+    ArticleJSON::Elements::Text.new(content: 'Check this out: ', bold: true)
+  end
+  let(:content_2) do
+    ArticleJSON::Elements::Text.new(content: 'Foo Bar', href: '/foo/bar')
+  end
+  let(:export) do
+    { role: 'body', text: '<strong>Check this out: </strong><a href="/foo/bar">Foo Bar</a>' }
+  end
+
+  describe '#export' do
+    subject { element.export }
+    it { should eq export }
+  end
+end

--- a/spec/article_json/export/apple_news/elements/text_spec.rb
+++ b/spec/article_json/export/apple_news/elements/text_spec.rb
@@ -1,0 +1,49 @@
+describe ArticleJSON::Export::AppleNews::Elements::Text do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Text.new(
+      content: content,
+      bold: bold,
+      italic: italic,
+      href: href
+    )
+  end
+  let(:content) { 'Foo Bar' }
+  let(:bold) { false }
+  let(:italic) { false }
+  let(:href) { nil }
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the source element is plain text' do
+      it { should eq content }
+    end
+
+    context 'when the source element contains a newline character' do
+      let(:content) { "Foo\nBar" }
+      let(:output) { 'Foo<br>Bar' }
+      it { should eq output }
+    end
+
+    context 'when the source element is bold text' do
+      let(:bold) { true }
+      let(:output) { '<strong>Foo Bar</strong>' }
+      it { should eq output }
+    end
+
+    context 'when the source element is italic text' do
+      let(:italic) { true }
+      let(:output) { '<em>Foo Bar</em>' }
+      it { should eq output }
+    end
+
+    context 'when the source element is italic and bold text' do
+      let(:bold) { true }
+      let(:italic) { true }
+      let(:output) { '<strong><em>Foo Bar</em></strong>' }
+      it { should eq output }
+    end
+  end
+end


### PR DESCRIPTION
Add the
- base
- text
- heading and
- paragraph

elements, along with their spec files.

Each element is returned as a component in the Apple News format with the required keys of `role` and `text` (Later this may be expanded to contain `layout`).

Neither is the key of `format` is applied- as it is not a required field, but we the Apple News format supports HTML and we are returning HTML.

We may wish to consider adding `format` at a later point.

RE `format` the Apple docs note:
> If format is set to html or markdown, neither Additions nor
> InlineTextStyles are supported.
> Default: none
> Possible values: markdown, html, none