### PR TITLE
BAN-2033 Add Apple news 'Videos' export feature

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -82,6 +82,7 @@ require_relative 'article_json/export/apple_news/elements/text'
 require_relative 'article_json/export/apple_news/elements/heading'
 require_relative 'article_json/export/apple_news/elements/paragraph'
 require_relative 'article_json/export/apple_news/elements/image'
+require_relative 'article_json/export/apple_news/elements/embed'
 require_relative 'article_json/export/apple_news/exporter'
 
 require_relative 'article_json/export/amp/elements/base'

--- a/lib/article_json/export/apple_news/elements/base.rb
+++ b/lib/article_json/export/apple_news/elements/base.rb
@@ -41,7 +41,7 @@ module ArticleJSON
                 list: nil,
                 quote: nil,
                 image: namespace::Image,
-                embed: nil,
+                embed: namespace::Embed,
                 text_box: nil
               }
             end

--- a/lib/article_json/export/apple_news/elements/embed.rb
+++ b/lib/article_json/export/apple_news/elements/embed.rb
@@ -1,0 +1,96 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class Embed < Base
+          # Embed
+          # @return [Hash]
+          def export
+            {
+              role: role,
+              URL: source_url,
+              caption: caption
+            }.compact
+          end
+
+          private
+
+          def role
+            @role ||=
+              case embed_type
+              when :youtube_video, :vimeo_video, :dailymotion_video
+                :embedwebvideo
+              when :facebook_video
+                :facebook_post
+              when :tweet
+                :tweet
+              when :slideshare
+                nil
+              when :soundcloud
+                nil
+              else
+                nil
+              end
+          end
+
+          def source_url
+            case embed_type
+            when :youtube_video
+              build_embeded_youtube_url
+            when :vimeo_video
+              build_embeded_vimeo_url
+            when :dailymotion_video
+              build_embeded_vimeo_url
+            when :facebook_video
+              build_facebook_video_url
+            when :tweet
+              build_twitter_url
+            when :slideshare
+              nil
+            when :soundcloud
+              nil
+            else
+              nil
+            end
+          end
+
+          def caption
+            return nil if role.nil?
+
+            @element.caption.first&.content
+          end
+
+          def build_embeded_youtube_url
+            "https://www.youtube.com/embed/#{embed_id}"
+          end
+
+          def build_embeded_vimeo_url
+            "https://player.vimeo.com/video/#{embed_id}"
+          end
+
+          def build_embeded_dailymotion_url
+            "https://geo.dailymotion.com/player.html?video=#{embed_id}"
+          end
+
+          def build_facebook_video_url
+            username, id = embed_id.to_s.split("/")
+            "https://www.facebook.com/#{username}/videos/#{id}"
+          end
+
+          def build_twitter_url
+            username, id = embed_id.to_s.split("/")
+            "https://twitter.com/#{username}/status/#{id}"
+          end
+
+          def embed_type
+            @embed_type ||= @element.embed_type.to_sym
+          end
+
+          def embed_id
+            @embed_id ||= @element.embed_id.to_sym
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/article_json/export/apple_news/exporter.rb
+++ b/lib/article_json/export/apple_news/exporter.rb
@@ -23,7 +23,7 @@ module ArticleJSON
               ArticleJSON::Export::AppleNews::Elements::Base
                 .build(element)
                 &.export
-            end
+            end.reject { |hash| hash.nil? || hash.empty? }
         end
       end
     end

--- a/spec/article_json/export/apple_news/elements/embed_spec.rb
+++ b/spec/article_json/export/apple_news/elements/embed_spec.rb
@@ -1,0 +1,79 @@
+describe ArticleJSON::Export::AppleNews::Elements::Embed do
+  subject(:element) { described_class.new(source_element) }
+  let(:type) { :youtube_video }
+  let(:embed_id) { '12345'}
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Caption text')] }
+
+  let(:url) { "https://www.youtube.com/embed/#{embed_id}" }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Embed.new(
+      embed_type: type,
+      embed_id: embed_id,
+      caption: caption,
+      tags: %w[foo bar]
+    )
+  end
+
+  let(:expected_json) do
+    {
+      URL: url,
+      caption: 'Caption text',
+      role: :embedwebvideo
+    }
+  end
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when passed an embeded youtube video with a caption' do
+      it { should eq expected_json }
+    end
+
+    context 'when passed an embeded youtube video without a caption' do
+      let(:caption) { [] }
+
+      let(:expected_json) { {URL: url, role: :embedwebvideo} }
+
+      it { should eq expected_json }
+    end
+
+    context 'when passed a tweet' do
+      let(:type) { :tweet }
+      let(:url) do
+        "https://twitter.com/#{embed_id.split("/")[0]}/status/#{embed_id.split("/")[1]}"
+      end
+      let(:caption) { [] }
+      let(:embed_id) { 'myTwitterAccount/1234' }
+
+      let(:expected_json) { {URL: url, role: :tweet} }
+
+      it { should eq expected_json }
+    end
+
+    context 'when passed a facebook_video' do
+      let(:type) { :facebook_video }
+      let(:url) do
+        "https://www.facebook.com/#{embed_id.split("/")[0]}/videos/#{embed_id.split("/")[1]}"
+      end
+      let(:caption) { [] }
+      let(:embed_id) { 'myFacebookAccount/1234' }
+
+      let(:expected_json) { {URL: url, role: :facebook_post} }
+
+      it { should eq expected_json }
+    end
+
+    context 'when passed a format unsupported by Apple News' do
+      types = [:slideshare, :soundcloud]
+      let(:expected_json) { {} }
+
+      types.each do |type|
+        let(:type) { type }
+        context "when the type level is #{type}" do
+          it { should eq expected_json }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use the Apple News Component `EmbedWebVideo` for YouTube, Dailymotion and Vimeo videos.

Also add facebook_post (for Facebook videos) & tweet components.

https://mydevex.atlassian.net/browse/BAN-2033