### PR TITLE
BAN-2137 Correct parsing/display of quotation marks

### DIFF
--- a/lib/article_json/export/apple_news/elements/paragraph.rb
+++ b/lib/article_json/export/apple_news/elements/paragraph.rb
@@ -25,7 +25,6 @@ module ArticleJSON
             @element.content.map do |child_element|
               text_exporter.new(child_element)
                 .export
-                .gsub(/[“”]/, '\\"')
             end.join
           end
         end

--- a/spec/article_json/export/apple_news/elements/paragraph_spec.rb
+++ b/spec/article_json/export/apple_news/elements/paragraph_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 describe ArticleJSON::Export::AppleNews::Elements::Paragraph do
   subject(:element) { described_class.new(source_element) }
 
@@ -13,8 +14,8 @@ describe ArticleJSON::Export::AppleNews::Elements::Paragraph do
   let(:exported_text) do
     {
       role: 'body',
-      text: '<strong>Check \\"this\\" out: </strong><a href="/foo/bar">Foo Bar</a>',
-      format: 'html'
+      text: '<strong>Check “this” out: </strong><a href="/foo/bar">Foo Bar</a>',
+      format: 'html',
     }
   end
 


### PR DESCRIPTION
Articles in Apple News were showing backslashes before quotation marks, which was because they were being escaped incorrectly.

Escaping the special characters is, in fact unnecessary.

https://mydevex.atlassian.net/browse/BAN-2137