### PR TITLE
BAN-2135 Remove unsupported tags from text in apple news format

### DIFF
--- a/lib/article_json/export/apple_news/elements/text.rb
+++ b/lib/article_json/export/apple_news/elements/text.rb
@@ -6,6 +6,10 @@ module ArticleJSON
           include ArticleJSON::Export::Common::HTML::Elements::Base
           include ArticleJSON::Export::Common::HTML::Elements::Text
 
+          UNSUPPORTED_HTML_TAGS = %w[title meta script noscript style link applet object iframe
+            noframes form select option optgroup
+          ].freeze
+
           # A Nokogiri object is returned with`super`, which is is then
           # returned as a either a string or as HTML (when not plain text),
           # both of which are compatible with Apple News format. Takes into
@@ -13,6 +17,23 @@ module ArticleJSON
           # @return [String]
           def export
             super.to_s
+          end
+
+          # @param [String] text
+          def create_text_nodes(text)
+            Nokogiri::HTML.fragment(sanitize_text(text).gsub(/\n/, '<br>')).children
+          end
+
+          # Removes UNSUPPORTED_TAGS from text
+          #
+          # @param [String] text
+          # @return [String]
+          def sanitize_text(text)
+            doc = Nokogiri::HTML.fragment(text)
+            UNSUPPORTED_HTML_TAGS.each do |tag|
+              doc.search(tag).each(&:remove)
+            end
+            doc.inner_html
           end
         end
       end

--- a/spec/article_json/export/apple_news/elements/text_spec.rb
+++ b/spec/article_json/export/apple_news/elements/text_spec.rb
@@ -45,5 +45,17 @@ describe ArticleJSON::Export::AppleNews::Elements::Text do
       let(:output) { '<strong><em>Foo Bar</em></strong>' }
       it { should eq output }
     end
+
+    context 'when the source element has unsupported tags' do
+      let(:content) do
+        'Normal text<script async>Some Script here</script>' \
+        '<select><option>OPtion 1</option></select>' \
+        '<form>form content</form>' \
+        '<p><em>text</em></p>' \
+        '<form><a href="#">Link</a></form>'
+      end
+      let(:output) { 'Normal text<p><em>text</em></p>' }
+      it { should eq output }
+    end
   end
 end


### PR DESCRIPTION
Sometimes we add scripts in the articles to embed some widgets such as audio players to have supplementary content in our news pages. These scripts sometimes have HTML tags that Apple doesn't allow in their news format. We have to omit them from the text.

This is the list of unsupported tags:
  title
  meta
  script
  noscript
  style
  link
  applet
  object
  iframe
  noframes
  form
  select
  option
  optgroup

https://mydevex.atlassian.net/browse/BAN-2135

As an example, in this article, we've been able to attach an audio player to our devex page by inserting a script:

<img width="1002" alt="Screenshot 2023-06-23 at 10 59 50" src="https://github.com/Devex/article_json/assets/825270/b5d4d6cd-e4ed-4855-a3a4-9b76ce806d91">

This is what it looks like in the Google Doc:

<img width="946" alt="Screenshot 2023-06-23 at 11 00 07" src="https://github.com/Devex/article_json/assets/825270/89674a87-0020-44f1-beed-7354464237da">
