### PR TITLE
BAN-2160 Show image captions on Apple News

### DIFF
--- a/lib/article_json/export/apple_news/elements/image.rb
+++ b/lib/article_json/export/apple_news/elements/image.rb
@@ -3,14 +3,38 @@ module ArticleJSON
     module AppleNews
       module Elements
         class Image < Base
+          # Image | Image, Caption
+          # @return [Hash, Array<Hash>]
+          def export
+            caption_text.nil? ? image : [image, caption]
+          end
+
+          private
           # Image
           # @return [Hash]
-          def export
+          def image
             {
-              role: "image",
+              role: 'image',
               URL: @element.source_url,
-              caption: @element.caption.first&.content
+              caption: caption_text,
             }.compact
+          end
+
+          # Caption
+          # @return [Hash]
+          def caption
+            {
+              role: 'caption',
+              text: caption_text,
+              layout: 'captionLayout',
+              textStyle: 'captionStyle',
+            }
+          end
+
+          # Caption Text
+          # @return [String]
+          def caption_text
+            @element.caption.first&.content
           end
         end
       end

--- a/lib/article_json/export/apple_news/exporter.rb
+++ b/lib/article_json/export/apple_news/exporter.rb
@@ -8,15 +8,21 @@ module ArticleJSON
         end
 
         # Return the components section of an Apple News Article as JSON
+        #
+        # Images and EmbededVideos are nested in an array with the components
+        # array when they contain captions. As Apple News skips over these
+        # nested arrays, we must flatten the array.
+        #
         # @return [String]
         def to_json
-          { components: components }.to_json
+          { components: components.flatten }.to_json
         end
 
         private
 
-        # Generate a string with the plain text representation of all elements
-        # @return [String]
+        # Generate an array with the plain text representation of all elements
+        # 
+        # @return [Array]
         def components
           @components ||=
             @elements.map do |element|

--- a/spec/article_json/export/apple_news/elements/image_spec.rb
+++ b/spec/article_json/export/apple_news/elements/image_spec.rb
@@ -13,29 +13,44 @@ describe ArticleJSON::Export::AppleNews::Elements::Image do
   let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Foo Bar')] }
   let(:alt) { 'Text description' }
 
-  let(:expected_json) { {URL: '/foo/bar.jpg', caption: 'Foo Bar', role: 'image'} }
-  
+  let(:expected_json) do
+    [
+      {
+        role: 'image',
+        URL: '/foo/bar.jpg',
+        caption: 'Foo Bar',
+      },
+      {
+        role: 'caption',
+        text: 'Foo Bar',
+        layout: 'captionLayout',
+        textStyle: 'captionStyle',
+      }
+    ]
+  end
+
   describe '#export' do
     subject { element.export }
 
-    context 'when the image is not floating' do
-      it { should eq expected_json }
-    end
+    context 'when there is a caption' do
+      context 'and when the image is not floating' do
+        it { should eq expected_json }
+      end
 
-    context 'when the image is floating on the left' do
-      let(:float) { :left }
-      it { should eq expected_json }
-    end
+      context 'and when the image is floating on the left' do
+        let(:float) { :left }
+        it { should eq expected_json }
+      end
 
-    context 'when the image is floating on the right' do
-      let(:float) { :right }
-      it { should eq expected_json }
+      context 'and when the image is floating on the right' do
+        let(:float) { :right }
+        it { should eq expected_json }
+      end
     end
 
     context 'when no caption is provided' do
       let(:caption) { [] }
-      let(:expected_json) { {:URL=>"/foo/bar.jpg", :role=>"image"} }
-
+      let(:expected_json) {{ role: 'image', URL: '/foo/bar.jpg'}}
       it { should eq expected_json }
     end
   end


### PR DESCRIPTION
The article_json gem is outputting JSON with which Apple News should be showing image captions in articles.
However these captions were not showing in any form.

This PR makes the necessary adjustments so that captions show in Apple News articles.

A follow-up PR with deal with the same issue for captions not showing for videos.

https://mydevex.atlassian.net/browse/BAN-2160