### PR TITLE
BAN-2160 Show captions for images and embed objects

### DIFF
--- a/lib/article_json/export/apple_news/elements/embed.rb
+++ b/lib/article_json/export/apple_news/elements/embed.rb
@@ -3,17 +3,42 @@ module ArticleJSON
     module AppleNews
       module Elements
         class Embed < Base
-          # Embed
-          # @return [Hash]
+          # Embed| Embed, Caption
+          # @return [Hash, Array<Hash>]
           def export
-            {
-              role: role,
-              URL: source_url,
-              caption: caption,
-            }.compact
+            caption_text.nil? ? embed : [embed, caption]
           end
 
           private
+
+          # Embed
+          # @return [Hash]
+          def embed
+            {
+              role: role,
+              URL: source_url,
+              caption: caption_text,
+            }.compact
+          end
+
+          # Caption
+          # @return [Hash]
+          def caption
+            {
+              role: 'caption',
+              text: caption_text,
+              layout: 'captionLayout',
+              textStyle: 'captionStyle',
+            }
+          end
+
+          # Caption Text
+          # @return [String]
+          def caption_text
+            return nil if role.nil?
+
+            @element.caption.first&.content
+          end
 
           def role
             @role ||=
@@ -52,12 +77,6 @@ module ArticleJSON
             else
               nil
             end
-          end
-
-          def caption
-            return nil if role.nil?
-
-            @element.caption.first&.content
           end
 
           def build_embeded_youtube_url

--- a/spec/article_json/export/apple_news/elements/embed_spec.rb
+++ b/spec/article_json/export/apple_news/elements/embed_spec.rb
@@ -2,7 +2,8 @@ describe ArticleJSON::Export::AppleNews::Elements::Embed do
   subject(:element) { described_class.new(source_element) }
   let(:type) { :youtube_video }
   let(:embed_id) { '12345'}
-  let(:caption) { [ArticleJSON::Elements::Text.new(content: 'Caption text')] }
+  let(:caption) { [ArticleJSON::Elements::Text.new(content: caption_text)] }
+  let(:caption_text) { 'Caption text' }
 
   let(:url) { "https://www.youtube.com/embed/#{embed_id}" }
 
@@ -27,12 +28,26 @@ describe ArticleJSON::Export::AppleNews::Elements::Embed do
     subject { element.export }
 
     context 'when passed an embeded youtube video with a caption' do
+      let(:expected_json) do
+        [
+          {
+            URL: url,
+            caption: caption_text,
+            role: :embedwebvideo,
+          },
+           {
+            layout: 'captionLayout',
+            role: 'caption',
+            text: caption_text,
+            textStyle: 'captionStyle',
+          },
+        ]
+      end
       it { should eq expected_json }
     end
 
     context 'when passed an embeded youtube video without a caption' do
       let(:caption) { [] }
-
       let(:expected_json) { {URL: url, role: :embedwebvideo} }
 
       it { should eq expected_json }


### PR DESCRIPTION
This PR makes the necessary adjustments so that captions show in AppleNews articles for `images` and `embed` objects.

The article_json gem was outputting JSON with which Apple News should be showing captions in articles. However these captions were not showing in any form. This PR corrects the building of Caption objects.

https://mydevex.atlassian.net/browse/BAN-2160