### PR TITLE
BAN-2159 Add support for pull quotes to Apple News

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -83,6 +83,7 @@ require_relative 'article_json/export/apple_news/elements/heading'
 require_relative 'article_json/export/apple_news/elements/paragraph'
 require_relative 'article_json/export/apple_news/elements/image'
 require_relative 'article_json/export/apple_news/elements/embed'
+require_relative 'article_json/export/apple_news/elements/quote'
 require_relative 'article_json/export/apple_news/exporter'
 
 require_relative 'article_json/export/amp/elements/base'

--- a/lib/article_json/export/apple_news/elements/base.rb
+++ b/lib/article_json/export/apple_news/elements/base.rb
@@ -39,7 +39,7 @@ module ArticleJSON
                 paragraph: namespace::Paragraph,
                 heading: namespace::Heading,
                 list: nil,
-                quote: nil,
+                quote: namespace::Quote,
                 image: namespace::Image,
                 embed: namespace::Embed,
                 text_box: nil

--- a/lib/article_json/export/apple_news/elements/quote.rb
+++ b/lib/article_json/export/apple_news/elements/quote.rb
@@ -1,0 +1,60 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class Quote < Base
+          include ArticleJSON::Export::Common::HTML::Elements::Base
+          include ArticleJSON::Export::Common::HTML::Elements::Text
+
+          def export
+            [quote, author]
+          end
+
+          private
+
+          # Quote
+          # @return [Hash]
+          def quote
+            {
+              role: 'pullquote',
+              text: quote_text,
+              format: 'html',
+              layout: 'pullquoteLayout',
+              textStyle: 'pullquoteStyle',
+            }
+          end
+
+          # Author
+          # @return [Hash]
+          def author
+            {
+              role: 'author',
+              text: author_text,
+              format: 'html',
+              layout: 'pullquoteAttributeLayout',
+              textStyle: 'quoteAttributeStyle',
+            }
+          end
+
+          def text_exporter
+            self.class.exporter_by_type(:text)
+          end
+
+          # Quote Text
+          # @return [String]
+          def quote_text
+            element = @element.content.first&.content.first
+            text_exporter.new(element).export
+          end
+
+          # Author Text
+          # @return [String]
+          def author_text
+            element = @element.caption.first
+            text_exporter.new(element).export
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/export/apple_news/elements/quote_spec.rb
+++ b/spec/article_json/export/apple_news/elements/quote_spec.rb
@@ -1,0 +1,110 @@
+describe ArticleJSON::Export::AppleNews::Elements::Quote do
+  subject(:element) { described_class.new(source_element) }
+
+  let(:source_element) do
+    ArticleJSON::Elements::Quote.new(
+      float: float,
+      content: quote,
+      caption: caption,
+    )
+  end
+  let(:caption) do
+    [
+      ArticleJSON::Elements::Text.new(
+        {
+          content: author,
+          bold: false,
+          italic: false,
+          href: href,
+        }
+      )
+    ]
+  end
+  let(:quote) do
+    [
+      ArticleJSON::Elements::Paragraph.new(
+        {
+          content: [
+            ArticleJSON::Elements::Text.new(
+              {
+                content: quote_text,
+                bold: bold,
+                italic: italic,
+                href: nil,
+              }
+            )
+          ]
+        }
+      )
+    ]
+  end
+  let(:output) do
+    [
+      {
+        role: 'pullquote',
+        text: quote_text_output,
+        format: 'html',
+        layout: 'pullquoteLayout',
+        textStyle: 'pullquoteStyle',
+      },
+      {
+        role: 'author',
+        text: author,
+        format: 'html',
+        layout: 'pullquoteAttributeLayout',
+        textStyle: 'quoteAttributeStyle',
+      }
+    ]
+  end
+  let(:quote_text) { 'Foo Bar' }
+  let(:quote_text_output) { 'Foo Bar' }
+  let(:author) { 'Homer Simpson'}
+  let(:float) { nil }
+  let(:bold) { false }
+  let(:italic) { false }
+  let(:href) { nil }
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the source element is plain text' do
+      it { should eq output }
+    end
+
+    context 'when the source element contains a newline character' do
+      let(:quote_text) { "Foo\nBar" }
+      let(:quote_text_output) { 'Foo<br>Bar' }
+      it { should eq output }
+    end
+
+    context 'when the source element contains bold text' do
+      let(:bold) { true }
+      let(:quote_text_output) { '<strong>Foo Bar</strong>' }
+      it { should eq output }
+    end
+
+    context 'when the source element contains a italic text' do
+      let(:italic) { true }
+      let(:quote_text_output) { '<em>Foo Bar</em>' }
+      it { should eq output }
+    end
+
+    context 'when the source element contains both bold and italic text' do
+      let(:bold) { true }
+      let(:italic) { true }
+      let(:quote_text_output) { '<strong><em>Foo Bar</em></strong>' }
+      it { should eq output }
+    end
+
+    context 'when the source element has unsupported tags' do
+      let(:quote_text) do
+        'Normal text<script async>Some Script here</script>' \
+        '<select><option>OPtion 1</option></select>' \
+        '<form>form content</form>' \
+        '<p><em>text</em></p>' \
+      end
+      let(:quote_text_output) { 'Normal text<p><em>text</em></p>' }
+      it { should eq output }
+    end
+  end
+end


### PR DESCRIPTION
Basic html is supported (bold and italics).

For this iteration the `float` value is ignored and all quotes appear the same.

There is the potential to support links too, which could be used to support linking quote authors to consultant profiles.

https://mydevex.atlassian.net/browse/BAN-2159