### PR TITLE
BAN-2158 Add text boxes to Apple News

### DIFF
--- a/lib/article_json.rb
+++ b/lib/article_json.rb
@@ -85,6 +85,7 @@ require_relative 'article_json/export/apple_news/elements/list'
 require_relative 'article_json/export/apple_news/elements/image'
 require_relative 'article_json/export/apple_news/elements/embed'
 require_relative 'article_json/export/apple_news/elements/quote'
+require_relative 'article_json/export/apple_news/elements/text_box'
 require_relative 'article_json/export/apple_news/exporter'
 
 require_relative 'article_json/export/amp/elements/base'

--- a/lib/article_json/export/apple_news/elements/base.rb
+++ b/lib/article_json/export/apple_news/elements/base.rb
@@ -42,7 +42,7 @@ module ArticleJSON
                 list: namespace::List,
                 image: namespace::Image,
                 embed: namespace::Embed,
-                text_box: nil
+                text_box: namespace::TextBox,
               }
             end
           end

--- a/lib/article_json/export/apple_news/elements/text_box.rb
+++ b/lib/article_json/export/apple_news/elements/text_box.rb
@@ -1,0 +1,56 @@
+module ArticleJSON
+  module Export
+    module AppleNews
+      module Elements
+        class TextBox < Base
+          include ArticleJSON::Export::Common::HTML::Elements::TextBox
+          # List
+          # @return [Hash]
+          def export
+            {
+              role: 'container',
+              layout: 'textBoxLayout',
+              style: 'textBoxStyle',
+              animation: {
+                type: 'appear',
+                userControllable: true,
+                initialAlpha: 0.0,
+              },
+              components: map_styles(elements),
+            }
+          end
+
+          private
+
+          # @return [Array]
+          def elements
+            @element.content.map do |child_element|
+              case child_element
+              when ArticleJSON::Elements::Heading
+                namespace::Heading.new(child_element).export
+              when ArticleJSON::Elements::Paragraph
+                namespace::Paragraph.new(child_element).export
+              when ArticleJSON::Elements::List
+                namespace::List.new(child_element).export
+              else
+                namespace::Text.new(child_element).export
+              end
+            end
+          end
+
+          # @return [Module]
+          def namespace
+            ArticleJSON::Export::AppleNews::Elements
+          end
+
+          # @return [Array]
+          def map_styles(elements)
+            elements.map do |child_element|
+              child_element.merge(layout: 'textBox' +  child_element[:layout].upcase_first)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/article_json/export/apple_news/elements/text_box_spec.rb
+++ b/spec/article_json/export/apple_news/elements/text_box_spec.rb
@@ -1,0 +1,139 @@
+describe ArticleJSON::Export::AppleNews::Elements::TextBox do
+  subject(:element) { described_class.new(source_element) }
+  let(:float) { nil }
+  let(:output) do
+    {
+      animation: { initialAlpha: 0.0, type: 'appear', userControllable: true },
+      components: components,
+      layout: 'textBoxLayout',
+      role: 'container',
+      style: 'textBoxStyle',
+    }
+  end
+
+  describe '#export' do
+    subject { element.export }
+
+    context 'when the list contains regular paragraphs' do
+      let(:source_element) do
+        ArticleJSON::Elements::TextBox.new(
+          float: float,
+          tags: [],
+          content: [
+            ArticleJSON::Elements::Heading.new(
+              content: 'A nice title for our left-aligned text box',
+              level: 2,
+            ),
+            ArticleJSON::Elements::Paragraph.new(
+              content: [
+                ArticleJSON::Elements::Text.new(
+                  content: 'A first paragraph with some text.',
+                  bold: false,
+                  italic: false,
+                  href: nil,
+                ),
+              ],
+            ),
+            ArticleJSON::Elements::Paragraph.new(
+              content: [
+                ArticleJSON::Elements::Text.new(
+                  content: 'Which continues here in the second paragraph.',
+                  bold: false,
+                  italic: false,
+                  href: nil,
+                ),
+              ],
+            ),
+          ],
+        )
+      end
+
+      let(:components) do
+        [
+          {
+            role:'heading2',
+            text:'A nice title for our left-aligned text box',
+            layout:'textBoxTitleLayout',
+            textStyle:'defaultTitle',
+          },
+          {
+            role:'body',
+            text:'A first paragraph with some text.',
+            format:'html',
+            layout:'textBoxBodyLayout',
+            textStyle:'bodyStyle',
+          },
+          {
+            role:'body',
+            text:'Which continues here in the second paragraph.',
+            format:'html',
+            layout:'textBoxBodyLayout',
+            textStyle:'bodyStyle',
+          },
+      ]
+      end
+
+      it { should eq output }
+    end
+
+    context 'when the text box contains a list' do
+      let(:source_element) do
+        ArticleJSON::Elements::TextBox.new(
+          float: float,
+          tags: [],
+          content: [
+            ArticleJSON::Elements::Heading.new(
+              content: 'Story Highlights',
+              level: 2,
+            ),
+            ArticleJSON::Elements::List.new(
+              list_type: 'unordered',
+              content: [
+                ArticleJSON::Elements::Paragraph.new(
+                  content: [
+                    ArticleJSON::Elements::Text.new(
+                      content: 'Text boxes really awesome!',
+                      bold: false,
+                      italic: false,
+                      href: nil,
+                    ),
+                  ],
+                ),
+                ArticleJSON::Elements::Paragraph.new(
+                  content: [
+                    ArticleJSON::Elements::Text.new(
+                      content: 'They also support lists!',
+                      bold: false,
+                      italic: false,
+                      href: nil,
+                    )
+                  ],
+                ),
+              ]
+            ),
+          ],
+        )
+      end
+
+      let(:components) do
+        [
+          {
+             layout:'textBoxTitleLayout',
+             role:'heading2',
+             text:'Story Highlights',
+             textStyle:'defaultTitle',
+          },
+          {
+             format:'html',
+             layout:'textBoxBodyLayout',
+             role:'body',
+             text: '<ul><li>Text boxes really awesome!</li><li>They also support lists!</li></ul>',
+             textStyle:'bodyStyle'
+          },
+        ]
+      end
+
+      it { should eq output }
+    end
+  end
+end


### PR DESCRIPTION
Create text box elements that:
- contain headings, lists and text
- have a distinguishable style and layout from headings, lists and text 
which are not in text-boxes

https://mydevex.atlassian.net/browse/BAN-2158