### PR TITLE
BAN-2158 Remove animation on text boxes

### DIFF
--- a/lib/article_json/export/apple_news/elements/text_box.rb
+++ b/lib/article_json/export/apple_news/elements/text_box.rb
@@ -41,7 +41,7 @@ module ArticleJSON
           # @return [Array]
           def map_styles(elements)
             elements.map do |child_element|
-              child_element.merge(layout: 'textBox' +  child_element[:layout].upcase_first)
+              child_element.merge(layout: 'textBox' +  child_element[:layout].sub(/\S/, &:upcase))
             end
           end
         end

--- a/lib/article_json/export/apple_news/elements/text_box.rb
+++ b/lib/article_json/export/apple_news/elements/text_box.rb
@@ -11,11 +11,6 @@ module ArticleJSON
               role: 'container',
               layout: 'textBoxLayout',
               style: 'textBoxStyle',
-              animation: {
-                type: 'appear',
-                userControllable: true,
-                initialAlpha: 0.0,
-              },
               components: map_styles(elements),
             }
           end

--- a/spec/article_json/export/apple_news/elements/text_box_spec.rb
+++ b/spec/article_json/export/apple_news/elements/text_box_spec.rb
@@ -3,7 +3,6 @@ describe ArticleJSON::Export::AppleNews::Elements::TextBox do
   let(:float) { nil }
   let(:output) do
     {
-      animation: { initialAlpha: 0.0, type: 'appear', userControllable: true },
       components: components,
       layout: 'textBoxLayout',
       role: 'container',


### PR DESCRIPTION
This animation was included to demo the effects available on Apple News.
This has been included in some draft articles, allowing it to be demoed, and can now be removed.

Also, remove the `upcase_first` method to remove dependance on Rails 5.

https://mydevex.atlassian.net/browse/BAN-2158