### PR TITLE
Use checkout v4 for actions

### DIFF
--- a/.github/workflows/check-google-doc.yml
+++ b/.github/workflows/check-google-doc.yml
@@ -2,7 +2,7 @@
 #
 # They are provided by a third-party and are governed by separate terms of service, privacy policy,
 # and support documentation.
-# 
+#
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,7 +1,8 @@
 # This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+#
+# They are provided by a third-party and are governed by separate terms of service, privacy policy,
+# and support documentation.
+#
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
@@ -24,7 +25,7 @@ jobs:
         ruby-version: [3.2, 2.7, 2.5]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
To avoid this warning that we are getting:
>The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.
>For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/