### PR TITLE
Undo `?event=push` suffix on readme badge and add `on push` to workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ It also provides functionalities to parse content from Google Document HTML expo
 
 ## Status
 [![Gem Version](https://badge.fury.io/rb/article_json.svg)](https://badge.fury.io/rb/article_json)
-![Check Google Doc](https://github.com/Devex/article_json/workflows/Check%20Google%20Doc/badge.svg?event=push)
-![rspec](https://github.com/Devex/article_json/workflows/rspec/badge.svg?event=push)
+[![Check Google Doc](https://github.com/Devex/article_json/workflows/Check%20Google%20Doc/badge.svg)]
+[![RSpec](https://github.com/Devex/article_json/workflows/rspec/badge.svg)]
 [![Code Climate](https://codeclimate.com/github/Devex/article_json/badges/gpa.svg)](https://codeclimate.com/github/Devex/article_json?event=push)
 [![Coverage Status](https://coveralls.io/repos/github/Devex/article_json/badge.svg?branch=master)](https://coveralls.io/github/Devex/article_json?branch=master)
 


### PR DESCRIPTION
Undo `?event=push` suffix on readme badge and add `on push` to workflow

Without the suffix:
<img width="149" alt="image" src="https://github.com/Devex/article_json/assets/32573223/87dc82d0-153b-4429-827b-31b7ecb722d0">
<img width="94" alt="image" src="https://github.com/Devex/article_json/assets/32573223/0742367f-c0b1-424e-8fbb-5d140d231a60">

With the suffix, the badges were showing as 'no status':
<img width="645" alt="image" src="https://github.com/Devex/article_json/assets/32573223/0b1cd4f0-bfa5-4d0e-a041-a5f3e9c5cd9c">

https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge